### PR TITLE
fix: clarify rate limit token guidance

### DIFF
--- a/scripts/setup_maa_framework.py
+++ b/scripts/setup_maa_framework.py
@@ -104,8 +104,8 @@ def _print_rate_limit_hint(
 
     if token_configured:
         print(
-            "[HINT] 当前 GITHUB_TOKEN 已触发 rate limit，"
-            "请等待限额恢复或更换 token 后重试"
+            "[HINT] 已配置 GITHUB_TOKEN，但 GitHub 请求仍触发 rate limit；"
+            "若此前收到 401，请更换为可访问目标仓库的 token，否则请等待限额恢复后重试"
         )
     else:
         print("[HINT] GitHub 请求已触发 rate limit，请配置环境变量 GITHUB_TOKEN 后重试")
@@ -148,7 +148,7 @@ def download_file(url: str, dest: Path):
                     _request(url, "application/octet-stream", False, token), timeout=600
                 )
             except urllib.error.HTTPError as retry_error:
-                _print_rate_limit_hint(retry_error, token_configured=False)
+                _print_rate_limit_hint(retry_error, token_configured=bool(token))
                 raise
         else:
             _print_rate_limit_hint(e, token_configured=bool(token))


### PR DESCRIPTION
## 背景

`setup_maa_framework.py` 使用 `GITHUB_TOKEN` 下载 GitHub Release 产物时，如果认证请求返回 401，会自动回退为匿名请求。

此前若匿名重试又触发 GitHub rate limit，脚本仍会提示用户“配置 GITHUB_TOKEN”。但此时 token 实际已经配置，该提示会误导用户。

## 改动

- 匿名重试被限流时，保留 `GITHUB_TOKEN` 已配置这一状态。
- 调整限流提示，区分两种处理方式：
  - 此前收到 401：更换为可访问目标仓库的 token。
  - token 已配置但仍被限流：等待限额恢复后重试。
- 不改变原有请求、匿名回退和异常传播逻辑。

## 影响

用户在 token 无效或权限不足、且匿名重试又被限流时，会收到与实际状态一致的处理建议。正常下载流程不受影响。

## 验证

- 使用 Python `compile()` 完成脚本语法检查。
- 核对认证请求 401、匿名回退及匿名请求限流的错误处理流程。
