### PR TITLE
feat(logs): add run log export action

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/ui/AppRoot.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/AppRoot.kt
@@ -397,6 +397,7 @@ fun AppRoot(
                         previewContent = previewContent.takeUnless { previewFullscreen },
                         runLog = { runLogState.value },
                         onEnterFullscreen = { previewFullscreen = true },
+                        onExportLogs = { exportSheetVisible = true },
                         onIntent = viewModel::onIntent,
                         modifier = Modifier.fillMaxSize(),
                     )

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/RunLogPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/RunLogPanel.kt
@@ -60,6 +60,7 @@ import java.util.Locale
 internal fun RunLogPanel(
     /** 取值而不是值：这里才是真正显示日志的地方，订阅落在这一层 */
     entries: () -> List<RunLogEntry>,
+    onExport: () -> Unit,
     onClear: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -94,6 +95,9 @@ internal fun RunLogPanel(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.weight(1f),
             )
+            TextButton(onClick = onExport) {
+                Text(stringResource(R.string.run_log_export))
+            }
             TextButton(onClick = onClear, enabled = all.isNotEmpty()) {
                 Text(stringResource(R.string.run_log_clear))
             }

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksScreen.kt
@@ -58,6 +58,7 @@ fun TasksScreen(
     /** 取值而不是值：日志面板没开时这一层不该跟着日志频率重组 */
     runLog: () -> List<RunLogEntry>,
     onEnterFullscreen: () -> Unit,
+    onExportLogs: () -> Unit,
     onIntent: (SessionIntent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -95,6 +96,7 @@ fun TasksScreen(
                 previewContent = previewContent,
                 runLog = runLog,
                 onEnterFullscreen = onEnterFullscreen,
+                onExportLogs = onExportLogs,
                 onIntent = onIntent,
             )
         }
@@ -108,6 +110,7 @@ private fun TasksContent(
     previewContent: (@Composable () -> Unit)?,
     runLog: () -> List<RunLogEntry>,
     onEnterFullscreen: () -> Unit,
+    onExportLogs: () -> Unit,
     onIntent: (SessionIntent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -188,6 +191,7 @@ private fun TasksContent(
                         when {
                             logOpen -> RunLogPanel(
                                 entries = runLog,
+                                onExport = onExportLogs,
                                 onClear = { onIntent(SessionIntent.ClearRunLog) },
                                 modifier = Modifier.fillMaxSize(),
                             )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -378,6 +378,7 @@
     <!-- Run log -->
     <string name="run_log_title">Run log</string>
     <string name="run_log_count">%1$d entries</string>
+    <string name="run_log_export">Export</string>
     <string name="run_log_clear">Clear</string>
     <string name="run_log_empty">No entries yet. MaaFramework output appears here once a run starts.</string>
     <string name="tasks_log">Log</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,6 +372,7 @@
     <!-- 运行日志 -->
     <string name="run_log_title">运行日志</string>
     <string name="run_log_count">%1$d 条</string>
+    <string name="run_log_export">导出</string>
     <string name="run_log_clear">清空</string>
     <string name="run_log_empty">还没有日志；开始任务后 MaaFramework 的运行输出会显示在这里</string>
     <string name="tasks_log">日志</string>


### PR DESCRIPTION
## Summary

- add an Export action to the run log panel
- connect the action to the existing log export sheet
- add Simplified Chinese and English labels for the new action

## Why

Users can inspect and clear the run log from the task screen, but they cannot start the existing export flow from that panel. This adds a direct entry point so diagnostics can be exported where they are viewed.

## Impact

The run log panel now exposes an Export button. Selecting it opens the existing export sheet; existing clear-log behavior is unchanged.

## Validation

- `git diff --cached --check` passed before commit.
- `./gradlew --no-daemon :app:testDebugUnitTest` compiled the changed Kotlin and resources successfully. The suite completed 313 tests with 309 passing, 2 skipped, and 2 failing because the untracked fixture `src/test/fixtures/PI/M9A/interface.json` is absent. The failures are `ProjectLoaderTest` and the dependent `RunPlanBuilderTest`.
