### PR TITLE
feat: allow narrowing release ABIs

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -139,7 +139,14 @@ python scripts/build_agent_bundle.py \
 ./gradlew :app:assembleRelease
 ```
 
-本地迭代可以在 `local.properties` 里写 `build.debugAbi=arm64-v8a`，debug 包就只打这一个 ABI。release 始终包含 `arm64-v8a` 和 `x86_64`。
+默认的 debug 和 release 包都包含 `arm64-v8a` 与 `x86_64`。可以在 `local.properties` 里按构建类型裁剪：
+
+```properties
+build.debugAbi=arm64-v8a
+build.releaseAbi=arm64-v8a
+```
+
+值为逗号分隔的 `arm64-v8a`、`x86_64`，未配置时仍默认包含两者。release 的 ABI 必须与铺入 `app/src/main/jniLibs` 的 MaaFramework，以及配方 `agent.abi` 声明并实际提供的 agent runtime 一致；否则 APK 会宣称支持一个缺少运行时的架构。
 
 改完配方或上游资源后，也可以只跑同步：
 

--- a/build-logic/convention/src/main/kotlin/com/aliothmoon/maafw/gradle/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/aliothmoon/maafw/gradle/AndroidApplicationConventionPlugin.kt
@@ -10,9 +10,6 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 
-/** ABIs that ship; a debug build can narrow to one via build.debugAbi to save build time */
-private val SHIPPED_ABIS = listOf("arm64-v8a", "x86_64")
-
 /** The package every build sits under; a profile only appends to it, it never replaces it */
 private const val BASE_APPLICATION_ID = "com.aliothmoon.maafw"
 
@@ -125,6 +122,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             }
 
             val debugAbis = listSetting("build.debugAbi").ifEmpty { SHIPPED_ABIS }
+            val releaseAbis = abiSetting("build.releaseAbi")
             android.buildTypes {
                 getByName("debug") {
                     ndk {
@@ -133,7 +131,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 }
                 getByName("release") {
                     ndk {
-                        abiFilters += SHIPPED_ABIS
+                        abiFilters += releaseAbis
                     }
                     // Resource shrinking stays off: it is a separate lever with its own
                     // failure mode, and nothing here has measured it yet
@@ -154,8 +152,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             // keeping both multiplied the test module's variants and let an unsuffixed one
             // through, which uninstalled the app on the developer's device
             //
-            // They keep release's full ABI set: collection needs API 33+ or a rooted adb
-            // session, so it often has to run on an emulator, and that one is x86_64.
+            // By default they keep release's full ABI set: collection needs API 33+ or a rooted adb
+            // session, so it often has to run on an emulator, and that one is x86_64. Narrowing
+            // build.releaseAbi also narrows these release-derived variants to the shipping shape.
             // configureEach rather than getByName - they do not exist yet when this runs
             android.buildTypes.configureEach {
                 if (!name.startsWith("nonMinified") && !name.startsWith("benchmarkRelease")) {

--- a/build-logic/convention/src/main/kotlin/com/aliothmoon/maafw/gradle/BuildSettings.kt
+++ b/build-logic/convention/src/main/kotlin/com/aliothmoon/maafw/gradle/BuildSettings.kt
@@ -3,6 +3,9 @@ package com.aliothmoon.maafw.gradle
 import org.gradle.api.Project
 import java.util.Properties
 
+/** Native ABIs the shell and its bundled MaaFramework/agent runtimes support. */
+internal val SHIPPED_ABIS = listOf("arm64-v8a", "x86_64")
+
 private fun Project.loadLocalProperties(): Properties = Properties().apply {
     val file = rootProject.file("local.properties")
     if (file.exists()) file.inputStream().use { load(it) }
@@ -27,3 +30,19 @@ internal fun Project.listSetting(key: String): List<String> =
     (loadLocalProperties().getProperty(key) ?: "").split(',')
         .map(String::trim)
         .filter(String::isNotEmpty)
+
+/**
+ * Resolve a build-type ABI setting, preserving the historical universal default while rejecting
+ * values for which the shell does not ship native dependencies.
+ */
+internal fun Project.abiSetting(key: String): List<String> {
+    val configured = listSetting(key)
+    if (configured.isEmpty()) return SHIPPED_ABIS
+
+    val unsupported = configured.filterNot(SHIPPED_ABIS::contains).distinct()
+    require(unsupported.isEmpty()) {
+        "$key contains unsupported ABI(s): ${unsupported.joinToString()}; " +
+            "supported values are ${SHIPPED_ABIS.joinToString()}"
+    }
+    return configured.distinct()
+}


### PR DESCRIPTION
## 变更

- 新增 `build.releaseAbi`，可在 `local.properties` 中按逗号配置 `arm64-v8a` / `x86_64`
- 未配置时继续默认双 ABI，保持现有行为
- 配置不支持的 ABI 时在 Gradle 配置阶段直接失败
- 更新集成文档，明确 release 外壳、MaaFramework 与 agent runtime 的 ABI 必须一致

`build.releaseAbi` 也会被 release 派生的 baseline profile / benchmark 变体继承，使性能测量保持与实际发布形态一致。

## 背景

PI 项目可能只提供单 ABI 的 MaaFramework 和 agent runtime。此前 release 外壳固定包含双 ABI，会让 APK 在另一架构设备上可安装，但运行时因缺少对应 framework/agent 而失败。这个开关允许项目生成真正的单 ABI release。

## 验证

- `.\gradlew.bat :app:testDebugUnitTest :app:assembleRelease`
- `build.releaseAbi=arm64-v8a`：release APK 仅包含 `lib/arm64-v8a`
- 未配置：release APK 同时包含 `lib/arm64-v8a` 和 `lib/x86_64`
- `build.releaseAbi=armeabi-v7a`：配置阶段按预期失败并报告支持列表
- consumer M9A：`pnpm check`

完整 `.\gradlew.bat build` 仍会在既有的 `:semi-icons:verifyReleaseResources` 失败（drawable 引用的 `attr/colorControlNormal` 在 library resource verification 中不可解析）；本次涉及的 app 单测、release 构建和 R8 keep 校验均通过。