### PR TITLE
fix(app): 固定主界面竖屏

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
             android:exported="true"
             android:label="${appLabel}"
             android:launchMode="singleTop"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.MaaFwApp.Starting"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>


### PR DESCRIPTION
## Summary
- 固定 MainActivity 为竖屏，避免主界面跟随系统自动旋转
- 保留全屏预览进入时临时横屏、退出后恢复竖屏的现有行为
- 不调整虚拟屏或被控应用相关逻辑

## Test plan
- git diff --check
- :app:assembleDebug 未能在本机完成：Gradle 启动时磁盘剩余约 130MiB，报 No space left on device