### PR TITLE
feat: 支持配置目标应用强制重启

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/di/RunnerModule.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/di/RunnerModule.kt
@@ -44,6 +44,7 @@ val runnerModule = module {
             nativeLibraryDir = context.applicationInfo.nativeLibraryDir,
             runMode = get<AppSettingsManager>().runMode::value,
             resolutionPreference = get<AppSettingsManager>().resolutionPreference::value,
+            forceRestartApp = get<AppSettingsManager>().forceRestartApp::value,
             debugMode = get<AppSettingsManager>().debugMode::value,
             scope = get(named<AppCoroutineScope>()),
             servicePort = get(),

--- a/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunner.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunner.kt
@@ -12,6 +12,7 @@ import com.aliothmoon.maafw.maa.MaaFwVersion
 import com.aliothmoon.maafw.maa.MaaGlobalOption
 import com.aliothmoon.maafw.maa.MaaLoggingLevel
 import com.aliothmoon.maafw.maa.MaaStatus
+import com.aliothmoon.maafw.remote.internal.ActivityUtils
 import com.aliothmoon.maafw.remote.internal.PrimaryDisplayManager
 import com.aliothmoon.maafw.remote.internal.VirtualDisplayManager
 import com.aliothmoon.maafw.runner.AgentPayload
@@ -292,6 +293,7 @@ class MaaRunner(private val agentHost: AgentHost) {
         // TouchArgs.contact 是 v5.12.3 起 fw 才填的合约字段，旧 fw 那 4 字节是栈残值，
         // 不过闸直接读会得到幻影手指；低于配对版本一律压 0（等价旧 bridge 单指行为）
         NativeBridgeLib.setContactSupport(MaaFwVersion.fillsTouchContact(lib.MaaVersion()))
+        ActivityUtils.forceRestartOnVirtualDisplay = payload.forceRestartApp
 
         val displayId = when (payload.displayMode) {
             DisplayMode.PRIMARY ->
@@ -484,8 +486,8 @@ class MaaRunner(private val agentHost: AgentHost) {
      * screen_resolution 必须与帧缓冲、触摸坐标空间三者一致，不一致时 screencap 立即失败
      * library_path 用裸名：bridge 已在本进程加载，控制单元 dlopen 同名即命中同一份
      *
-     * 虚拟屏模式下 force_stop 必须为 true：目标应用若已在主屏上跑着，startActivity 会复用它在主屏的
-     * 既有 task，虚拟屏上拿不到画面。先杀掉再拉起，进程才会落到虚拟屏上
+     * 虚拟屏模式下 controller 继续请求 force_stop：目标应用若已在主屏上跑着，startActivity 会复用
+     * 它在主屏的既有 task，虚拟屏上拿不到画面。是否真的强停由 ActivityUtils 按用户设置判定
      * 主屏模式反过来——目标就在主屏，杀掉只会把用户已经摆好的现场清空
      */
     private fun buildControllerConfig(payload: RunPlanPayload, displayId: Int): String {

--- a/app/src/main/java/com/aliothmoon/maafw/remote/internal/ActivityUtils.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/internal/ActivityUtils.kt
@@ -32,6 +32,10 @@ object ActivityUtils {
     @Volatile
     var forceFullscreenOnVirtualDisplay: Boolean = false
 
+    /** false 时仅在目标应用未确认位于目标虚拟屏的情况下强停；进程默认 true 以保持旧行为 */
+    @Volatile
+    var forceRestartOnVirtualDisplay: Boolean = true
+
     private val setLaunchWindowingMode by lazy {
         runCatching {
             ActivityOptions::class.java
@@ -85,6 +89,18 @@ object ActivityUtils {
     @JvmStatic
     fun packageNameOf(spec: String): String = componentOf(spec)?.packageName ?: spec
 
+    /** 无法确认 display 时返回 true，保守沿用旧强停行为 */
+    internal fun shouldForceStopBeforeStart(
+        requestedForceStop: Boolean,
+        targetDisplayId: Int,
+        currentDisplayId: Int?,
+        forceRestart: Boolean,
+    ): Boolean = requestedForceStop && (
+        targetDisplayId == Display.DEFAULT_DISPLAY ||
+            forceRestart ||
+            currentDisplayId != targetDisplayId
+        )
+
     private fun componentOf(spec: String): ComponentName? =
         spec.takeIf { it.contains('/') }?.let { ComponentName.unflattenFromString(it) }
 
@@ -121,8 +137,19 @@ object ActivityUtils {
         }
         intent.addFlags(flag)
 
-        if (forceStop) {
+        val currentDisplayId = if (
+            forceStop &&
+            !forceRestartOnVirtualDisplay &&
+            displayId != Display.DEFAULT_DISPLAY
+        ) {
+            getAppDisplayId(targetPackage)
+        } else {
+            null
+        }
+        if (shouldForceStopBeforeStart(forceStop, displayId, currentDisplayId, forceRestartOnVirtualDisplay)) {
             ServiceManager.getActivityManager().forceStopPackage(targetPackage)
+        } else {
+            Ln.i("startApp keeps $targetPackage alive on display $displayId")
         }
         Ln.i("startApp ${intent.component?.flattenToShortString()}")
 

--- a/app/src/main/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPort.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPort.kt
@@ -51,6 +51,8 @@ class MaaFrameworkRunnerPort(
     private val runMode: () -> RunMode,
     /** 同上：分辨率偏好可能两轮之间被改 */
     private val resolutionPreference: () -> ResolutionPreference,
+    /** 同上：StartApp 的强停策略可能两轮之间被改 */
+    private val forceRestartApp: () -> Boolean,
     /** 调试模式：传给特权进程 setup 的 isDebug，开启 MaaFramework 详细日志 */
     private val debugMode: () -> Boolean,
     private val scope: CoroutineScope,
@@ -324,6 +326,7 @@ class MaaFrameworkRunnerPort(
             screenWidth = width,
             screenHeight = height,
             displayMode = mode.displayMode,
+            forceRestartApp = forceRestartApp(),
             tasks = plan.tasks.map {
                 RuntimeTaskPayload(
                     taskName = it.taskName,

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunPlanPayload.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunPlanPayload.kt
@@ -21,6 +21,11 @@ data class RunPlanPayload(
     val screenHeight: Int,
     /** [com.aliothmoon.maafw.constant.DisplayMode] 取值；决定 Runner 找谁要屏幕尺寸 */
     val displayMode: Int = DisplayMode.BACKGROUND,
+    /**
+     * 后台模式 StartApp 前是否无条件强停目标应用。
+     * 线格式默认 true 是为了旧 payload 解码后保持既有行为；用户设置本身默认 false。
+     */
+    val forceRestartApp: Boolean = true,
     val tasks: List<RuntimeTaskPayload>,
     /** PI 声明的 agent，按声明顺序；空表示本次不起 agent */
     val agents: List<AgentPayload> = emptyList(),

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunPlanPayload.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunPlanPayload.kt
@@ -23,7 +23,7 @@ data class RunPlanPayload(
     val displayMode: Int = DisplayMode.BACKGROUND,
     /**
      * 后台模式 StartApp 前是否无条件强停目标应用。
-     * 线格式默认 true 是为了旧 payload 解码后保持既有行为；用户设置本身默认 false。
+     * 线格式默认 true 是为了旧 payload 解码后保持既有行为；用户设置本身默认 true。
      */
     val forceRestartApp: Boolean = true,
     val tasks: List<RuntimeTaskPayload>,

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
@@ -63,6 +63,8 @@ data class SessionUiState(
     /** 全局的跑完关目标应用；与 ScheduleStrategy 上的同名选项并存，本项优先 */
     val closeAppAfterTask: Boolean = false,
     val touchPreviewEnabled: Boolean = true,
+    /** 后台模式 StartApp 前是否无条件强停目标应用 */
+    val forceRestartApp: Boolean = false,
     /** 定时任务的亮屏解锁；逐条规则的收尾选项在 ScheduleStrategy 上，不在这 */
     val wakeUnlockEnabled: Boolean = false,
     val wakeCredential: String = "",
@@ -253,6 +255,9 @@ sealed interface SessionIntent {
 
     /** 预览上是否画注入的触点 */
     data class SetTouchPreviewEnabled(val enabled: Boolean) : SessionIntent
+
+    /** 后台模式 StartApp 前是否无条件强停目标应用；改动下一轮生效 */
+    data class SetForceRestartApp(val enabled: Boolean) : SessionIntent
 
     data class SetTelemetryEnabled(val enabled: Boolean) : SessionIntent
 

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
@@ -64,7 +64,7 @@ data class SessionUiState(
     val closeAppAfterTask: Boolean = false,
     val touchPreviewEnabled: Boolean = true,
     /** 后台模式 StartApp 前是否无条件强停目标应用 */
-    val forceRestartApp: Boolean = false,
+    val forceRestartApp: Boolean = true,
     /** 定时任务的亮屏解锁；逐条规则的收尾选项在 ScheduleStrategy 上，不在这 */
     val wakeUnlockEnabled: Boolean = false,
     val wakeCredential: String = "",

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -72,6 +72,7 @@ private data class SettingsSnapshot(
     val resolutionPreference: ResolutionPreference,
     val debugMode: Boolean,
     val themeStyle: ThemeStyle = ThemeStyle.DEFAULT,
+    val forceRestartApp: Boolean = false,
     val env: EnvSnapshot = EnvSnapshot(),
     val quick: QuickSnapshot = QuickSnapshot(),
 )
@@ -137,6 +138,8 @@ class SessionViewModel(
         SettingsSnapshot(runMode, overlayMode, screenSaver, resolution, debug)
     }.combine(appSettings.themeStyle) { snapshot, style ->
         snapshot.copy(themeStyle = style)
+    }.combine(appSettings.forceRestartApp) { snapshot, forceRestart ->
+        snapshot.copy(forceRestartApp = forceRestart)
     }.combine(
         combine(appSettings.wakeUnlockEnabled, appSettings.wakeCredential, ::EnvSnapshot),
     ) { snapshot, env -> snapshot.copy(env = env) }
@@ -260,6 +263,7 @@ class SessionViewModel(
             screenSaverEnabled = settings.screenSaverEnabled,
             closeAppAfterTask = settings.quick.closeAppAfterTask,
             touchPreviewEnabled = settings.quick.touchPreviewEnabled,
+            forceRestartApp = settings.forceRestartApp,
             telemetryEnabled = settings.quick.telemetryEnabled,
             wakeUnlockEnabled = settings.env.wakeUnlockEnabled,
             wakeCredential = settings.env.wakeCredential,
@@ -474,6 +478,9 @@ class SessionViewModel(
 
             is SessionIntent.SetTouchPreviewEnabled ->
                 appSettings.setTouchPreviewEnabled(intent.enabled)
+
+            is SessionIntent.SetForceRestartApp ->
+                appSettings.setForceRestartApp(intent.enabled)
 
             SessionIntent.ShowOverlay -> openControlOverlay()
             SessionIntent.ApplyForegroundResolution -> applyForegroundResolution()

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -72,7 +72,7 @@ private data class SettingsSnapshot(
     val resolutionPreference: ResolutionPreference,
     val debugMode: Boolean,
     val themeStyle: ThemeStyle = ThemeStyle.DEFAULT,
-    val forceRestartApp: Boolean = false,
+    val forceRestartApp: Boolean = true,
     val env: EnvSnapshot = EnvSnapshot(),
     val quick: QuickSnapshot = QuickSnapshot(),
 )

--- a/app/src/main/java/com/aliothmoon/maafw/settings/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/settings/AppSettings.kt
@@ -58,6 +58,10 @@ data class AppSettings(
     @PrefKey(default = "true")
     val touchPreviewEnabled: String = "true",
 
+    /** 后台模式下 StartApp 前是否无条件强停目标应用；默认关，已在当前虚拟屏时保留现场 */
+    @PrefKey(default = "false")
+    val forceRestartApp: String = "false",
+
     /** [com.aliothmoon.maafw.runner.ResolutionPreference] 的 name */
     @PrefKey(default = "P720")
     val resolutionPreference: String = "P720",

--- a/app/src/main/java/com/aliothmoon/maafw/settings/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/settings/AppSettings.kt
@@ -58,9 +58,9 @@ data class AppSettings(
     @PrefKey(default = "true")
     val touchPreviewEnabled: String = "true",
 
-    /** 后台模式下 StartApp 前是否无条件强停目标应用；默认关，已在当前虚拟屏时保留现场 */
-    @PrefKey(default = "false")
-    val forceRestartApp: String = "false",
+    /** 后台模式下 StartApp 前是否无条件强停目标应用；默认开，保持既有强停行为 */
+    @PrefKey(default = "true")
+    val forceRestartApp: String = "true",
 
     /** [com.aliothmoon.maafw.runner.ResolutionPreference] 的 name */
     @PrefKey(default = "P720")

--- a/app/src/main/java/com/aliothmoon/maafw/settings/AppSettingsGateway.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/settings/AppSettingsGateway.kt
@@ -30,6 +30,10 @@ interface AppSettingsGateway {
     val touchPreviewEnabled: StateFlow<Boolean>
     suspend fun setTouchPreviewEnabled(enabled: Boolean)
 
+    /** 后台模式 StartApp 前是否无条件强停目标应用 */
+    val forceRestartApp: StateFlow<Boolean>
+    suspend fun setForceRestartApp(enabled: Boolean)
+
     val resolutionPreference: StateFlow<ResolutionPreference>
     suspend fun setResolutionPreference(preference: ResolutionPreference)
 

--- a/app/src/main/java/com/aliothmoon/maafw/settings/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/settings/AppSettingsManager.kt
@@ -81,6 +81,9 @@ class AppSettingsManager(private val context: Context) : AppSettingsGateway {
     private val _touchPreviewEnabled = MutableStateFlow(defaults.touchPreviewEnabled.toBoolean())
     override val touchPreviewEnabled: StateFlow<Boolean> = _touchPreviewEnabled.asStateFlow()
 
+    private val _forceRestartApp = MutableStateFlow(defaults.forceRestartApp.toBoolean())
+    override val forceRestartApp: StateFlow<Boolean> = _forceRestartApp.asStateFlow()
+
     private val _eventNotificationLevel =
         MutableStateFlow(parseEventNotificationLevel(defaults.eventNotificationLevel))
     val eventNotificationLevel: StateFlow<EventNotificationLevel> = _eventNotificationLevel.asStateFlow()
@@ -130,6 +133,7 @@ class AppSettingsManager(private val context: Context) : AppSettingsGateway {
                 _screenSaverEnabled.value = s.screenSaverEnabled.toBoolean()
                 _closeAppAfterTask.value = s.closeAppAfterTask.toBoolean()
                 _touchPreviewEnabled.value = s.touchPreviewEnabled.toBoolean()
+                _forceRestartApp.value = s.forceRestartApp.toBoolean()
                 _resolutionPreference.value = parseResolutionPreference(s.resolutionPreference)
                 _debugMode.value = s.debugMode.toBoolean()
                 _themeStyle.value = parseThemeStyle(s.themeStyle)
@@ -181,6 +185,10 @@ class AppSettingsManager(private val context: Context) : AppSettingsGateway {
 
     override suspend fun setTouchPreviewEnabled(enabled: Boolean): Unit = with(AppSettingsSchema) {
         context.dataStore.edit { it[touchPreviewEnabled] = enabled.toString() }
+    }
+
+    override suspend fun setForceRestartApp(enabled: Boolean): Unit = with(AppSettingsSchema) {
+        context.dataStore.edit { it[forceRestartApp] = enabled.toString() }
     }
 
     override suspend fun setResolutionPreference(preference: ResolutionPreference): Unit = with(AppSettingsSchema) {

--- a/app/src/main/java/com/aliothmoon/maafw/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/settings/SettingsScreen.kt
@@ -614,6 +614,17 @@ private fun OtherCard(
             enabled = !locked,
             onSelect = { onIntent(SessionIntent.SetResolutionPreference(it)) },
         )
+        Spacer(Modifier.height(MaaDesignTokens.Spacing.sm))
+        MaaSwitchRow(
+            label = stringResource(R.string.settings_force_restart_app),
+            checked = state.forceRestartApp,
+            onCheckedChange = { onIntent(SessionIntent.SetForceRestartApp(it)) },
+        )
+        Text(
+            text = stringResource(R.string.settings_force_restart_app_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         // 开发版 PI 一律不上报（TelemetryController 也照此拦），留个点不动的开关只会让人以为坏了
         if (state.telemetryDeclared && !state.telemetryLockedByVersion) {
             Spacer(Modifier.height(MaaDesignTokens.Spacing.sm))

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -131,6 +131,8 @@
     <string name="settings_run_mode_foreground">Foreground mode</string>
     <string name="settings_run_mode_hint_background">Runs on a separate virtual display so the phone stays usable; resolution derived from the project declaration</string>
     <string name="settings_run_mode_hint_foreground">Drives the current screen directly, occupying the phone while running; the target app is not restarted and preview touch is disabled</string>
+    <string name="settings_force_restart_app">Force-restart the target app</string>
+    <string name="settings_force_restart_app_desc">Try enabling this when the target app cannot start normally</string>
     <string name="settings_resource">Server selection</string>
     <string name="settings_no_resources">The project provides no selectable servers</string>
     <string name="settings_current_resource">Current resource</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="settings_run_mode_foreground">前台模式</string>
     <string name="settings_run_mode_hint_background">在独立的虚拟屏幕上运行任务，手机可正常使用；分辨率由项目声明推导</string>
     <string name="settings_run_mode_hint_foreground">直接操作当前屏幕，运行期间手机被占用；不会重启目标应用，预览里也不接管触摸</string>
+    <string name="settings_force_restart_app">强制重启目标应用</string>
+    <string name="settings_force_restart_app_desc">无法正常启动目标app时可尝试开启此项</string>
     <string name="settings_resource">服务器选择</string>
     <string name="settings_no_resources">项目未提供可选服务器</string>
     <string name="settings_current_resource">当前资源</string>

--- a/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
@@ -37,6 +37,8 @@ open class FakePrivilegedService : RemoteService {
     var running: Boolean = false
     var setupResult: Boolean = true
     var startRunResult: Boolean = true
+    var startRunJsons: MutableList<String> = mutableListOf()
+        private set
     var stopRunCount: Int = 0
         private set
 
@@ -91,6 +93,7 @@ open class FakePrivilegedService : RemoteService {
     }
     override fun startRun(runPlanJson: String?): Boolean {
         if (!startRunResult) return false
+        startRunJsons += runPlanJson.orEmpty()
         running = true
         return true
     }

--- a/app/src/test/java/com/aliothmoon/maafw/remote/ActivityUtilsDecisionTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/remote/ActivityUtilsDecisionTest.kt
@@ -1,0 +1,73 @@
+package com.aliothmoon.maafw.remote.internal
+
+import android.view.Display
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActivityUtilsDecisionTest {
+
+    @Test
+    fun `force restart is skipped only when app is confirmed on target virtual display`() {
+        val targetDisplay = 12
+
+        assertFalse(
+            ActivityUtils.shouldForceStopBeforeStart(
+                requestedForceStop = true,
+                targetDisplayId = targetDisplay,
+                currentDisplayId = targetDisplay,
+                forceRestart = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `main display or unknown placement keeps legacy force restart`() {
+        val targetDisplay = 12
+
+        assertTrue(
+            ActivityUtils.shouldForceStopBeforeStart(
+                requestedForceStop = true,
+                targetDisplayId = targetDisplay,
+                currentDisplayId = Display.DEFAULT_DISPLAY,
+                forceRestart = false,
+            ),
+        )
+        assertTrue(
+            ActivityUtils.shouldForceStopBeforeStart(
+                requestedForceStop = true,
+                targetDisplayId = targetDisplay,
+                currentDisplayId = null,
+                forceRestart = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `explicit force restart and primary display preserve current behavior`() {
+        assertTrue(
+            ActivityUtils.shouldForceStopBeforeStart(
+                requestedForceStop = true,
+                targetDisplayId = Display.DEFAULT_DISPLAY,
+                currentDisplayId = Display.DEFAULT_DISPLAY,
+                forceRestart = false,
+            ),
+        )
+        assertTrue(
+            ActivityUtils.shouldForceStopBeforeStart(
+                requestedForceStop = true,
+                targetDisplayId = 12,
+                currentDisplayId = 12,
+                forceRestart = true,
+            ),
+        )
+        assertFalse(
+            ActivityUtils.shouldForceStopBeforeStart(
+                requestedForceStop = false,
+                targetDisplayId = 12,
+                currentDisplayId = Display.DEFAULT_DISPLAY,
+                forceRestart = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPortTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPortTest.kt
@@ -20,8 +20,10 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -67,6 +69,7 @@ class MaaFrameworkRunnerPortTest {
         scope: TestScope,
         service: FakePrivilegedService = FakePrivilegedService(),
         servicePort: FakePrivilegedServicePort = FakePrivilegedServicePort(service),
+        forceRestartApp: () -> Boolean = { false },
     ): Pair<MaaFrameworkRunnerPort, FakePrivilegedServicePort> {
         val installer = mockk<PiInstaller>()
         every { installer.installedDir() } returns temp.newFolder("pi")
@@ -76,6 +79,7 @@ class MaaFrameworkRunnerPortTest {
             nativeLibraryDir = "/lib",
             runMode = { RunMode.BACKGROUND },
             resolutionPreference = { ResolutionPreference.P720 },
+            forceRestartApp = forceRestartApp,
             debugMode = { false },
             scope = scope.backgroundScope,
             servicePort = servicePort,
@@ -83,6 +87,18 @@ class MaaFrameworkRunnerPortTest {
         // JVM 单测构造不了 AIDL Stub；本文件只测 phase，不测回调转发
         runner.bindRunnerCallback = {}
         return runner to servicePort
+    }
+
+    @Test
+    fun `force restart preference is carried in run payload`() = runTest(dispatcher) {
+        val service = FakePrivilegedService()
+        val (runner, _) = port(this, service)
+
+        runner.start(plan())
+        advanceUntilIdle()
+
+        val payload = runPlanWireJson.decodeFromString<RunPlanPayload>(service.startRunJsons.single())
+        assertFalse(payload.forceRestartApp)
     }
 
     @Test

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -573,13 +573,13 @@ class SessionViewModelTest {
         backgroundScope.launch { vm.uiState.collect {} }
         advanceUntilIdle()
 
-        assertFalse(vm.uiState.value.forceRestartApp)
+        assertTrue(vm.uiState.value.forceRestartApp)
 
-        vm.onIntent(SessionIntent.SetForceRestartApp(true))
+        vm.onIntent(SessionIntent.SetForceRestartApp(false))
         advanceUntilIdle()
 
-        assertTrue(settings.forceRestartApp.value)
-        assertTrue(vm.uiState.value.forceRestartApp)
+        assertFalse(settings.forceRestartApp.value)
+        assertFalse(vm.uiState.value.forceRestartApp)
     }
 
     @Test

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -567,6 +567,22 @@ class SessionViewModelTest {
     }
 
     @Test
+    fun `force restart setting is persisted and projected into ui state`() = runTest(mainDispatcher) {
+        val settings = FakeAppSettingsGateway()
+        val (vm, _, _) = createVm(settings = settings)
+        backgroundScope.launch { vm.uiState.collect {} }
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.forceRestartApp)
+
+        vm.onIntent(SessionIntent.SetForceRestartApp(true))
+        advanceUntilIdle()
+
+        assertTrue(settings.forceRestartApp.value)
+        assertTrue(vm.uiState.value.forceRestartApp)
+    }
+
+    @Test
     fun `theme change is allowed while busy`() = runTest(mainDispatcher) {
         val runner = StubRunnerPort(
             scope = backgroundScope,

--- a/app/src/test/java/com/aliothmoon/maafw/settings/FakeAppSettingsGateway.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/settings/FakeAppSettingsGateway.kt
@@ -40,7 +40,7 @@ class FakeAppSettingsGateway : AppSettingsGateway {
         touchPreviewEnabled.value = enabled
     }
 
-    override val forceRestartApp = MutableStateFlow(false)
+    override val forceRestartApp = MutableStateFlow(true)
 
     override suspend fun setForceRestartApp(enabled: Boolean) {
         forceRestartApp.value = enabled

--- a/app/src/test/java/com/aliothmoon/maafw/settings/FakeAppSettingsGateway.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/settings/FakeAppSettingsGateway.kt
@@ -40,6 +40,12 @@ class FakeAppSettingsGateway : AppSettingsGateway {
         touchPreviewEnabled.value = enabled
     }
 
+    override val forceRestartApp = MutableStateFlow(false)
+
+    override suspend fun setForceRestartApp(enabled: Boolean) {
+        forceRestartApp.value = enabled
+    }
+
     override val resolutionPreference = MutableStateFlow(ResolutionPreference.P720)
 
     override suspend fun setResolutionPreference(preference: ResolutionPreference) {


### PR DESCRIPTION
## Summary
- 在其他设置中新增“强制重启目标应用”，默认关闭
- 开启后保持原有 StartApp 前强制停止行为；关闭时仅当目标应用未确认处于当前虚拟屏时才重启
- 补充设置持久化、payload 传递和强停决策测试

## Test
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:assembleDebug