### PR TITLE
ci: 全量格式化并自动写回

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+ktlint_code_style = android_studio
+ktlint_standard_backing-property-naming = disabled
+ktlint_standard_filename = disabled
+ktlint_standard_function-naming = disabled
+ktlint_standard_kdoc = disabled
+ktlint_standard_max-line-length = disabled
+ktlint_standard_property-naming = disabled
+ktlint_standard_value-parameter-comment = disabled
+
+[*.{json,yaml,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ on:
       - "gradle/libs.versions.toml"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: format-${{ github.ref }}
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   spotless:
-    name: Check changed Kotlin files
+    name: Format Kotlin files
     runs-on: ubuntu-latest
 
     steps:
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -42,29 +43,31 @@ jobs:
           distribution: temurin
           java-version: "17"
 
-      - name: Resolve formatting base
-        id: base
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
+      - name: Run Spotless
+        run: ./gradlew spotlessApply
+
+      - name: Commit formatting changes
         shell: bash
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          if [[ -n "$PULL_REQUEST_BASE_SHA" ]]; then
-            base_ref="$PULL_REQUEST_BASE_SHA"
-          elif [[ -n "$PUSH_BEFORE_SHA" && ! "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
-            base_ref="$PUSH_BEFORE_SHA"
-          else
-            base_ref="origin/$DEFAULT_BRANCH"
+          if [[ -z "$(git status --porcelain --untracked-files=all -- "*.kt" "*.kts")" ]]; then
+            echo "No formatting changes."
+            exit 0
           fi
 
-          base_sha="$(git rev-parse "$base_ref^{commit}")"
-          echo "sha=$base_sha" >>"$GITHUB_OUTPUT"
-          echo "Formatting base: $base_sha"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "*.kt" "*.kts"
+          git commit -m "style: 格式化 Kotlin"
 
-      - name: Run Spotless
-        env:
-          SPOTLESS_RATCHET_FROM: ${{ steps.base.outputs.sha }}
-        run: ./gradlew spotlessCheck -PspotlessRatchetFrom="$SPOTLESS_RATCHET_FROM"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            branch="$GITHUB_HEAD_REF"
+          else
+            branch="$GITHUB_REF_NAME"
+          fi
+          git push origin "HEAD:$branch"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,70 @@
+name: Format
+
+on:
+  pull_request:
+    paths:
+      - "**.kt"
+      - "**.kts"
+      - ".editorconfig"
+      - ".github/workflows/format.yml"
+      - "build.gradle.kts"
+      - "gradle/libs.versions.toml"
+  push:
+    paths:
+      - "**.kt"
+      - "**.kts"
+      - ".editorconfig"
+      - ".github/workflows/format.yml"
+      - "build.gradle.kts"
+      - "gradle/libs.versions.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: format-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spotless:
+    name: Check changed Kotlin files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Resolve formatting base
+        id: base
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -n "$PULL_REQUEST_BASE_SHA" ]]; then
+            base_ref="$PULL_REQUEST_BASE_SHA"
+          elif [[ -n "$PUSH_BEFORE_SHA" && ! "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+            base_ref="$PUSH_BEFORE_SHA"
+          else
+            base_ref="origin/$DEFAULT_BRANCH"
+          fi
+
+          base_sha="$(git rev-parse "$base_ref^{commit}")"
+          echo "sha=$base_sha" >>"$GITHUB_OUTPUT"
+          echo "Formatting base: $base_sha"
+
+      - name: Run Spotless
+        env:
+          SPOTLESS_RATCHET_FROM: ${{ steps.base.outputs.sha }}
+        run: ./gradlew spotlessCheck -PspotlessRatchetFrom="$SPOTLESS_RATCHET_FROM"

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ local.properties
 *.jks
 *.b64
 AGENTS.md
-/.vscode/
+/.vscode/*
+!/.vscode/settings.json
+!/.vscode/extensions.json
 
 # Generated files
 bin/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "EditorConfig.EditorConfig",
+    "richardwillis.vscode-spotless-gradle",
+    "vscjava.vscode-gradle"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[kotlin]": {
+    "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.spotlessGradle": true
+    },
+    "spotlessGradle.diagnostics.enable": true,
+    "spotlessGradle.format.enable": true
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.spotless)
     alias(libs.plugins.android.application) apply false
     // 声明 kotlin-jvm 是为了把 KGP 2.3.21 钉在共享构建 classpath 上；
     // 不声明的话 AGP 9 的内置 Kotlin 会用它自带的版本，与 :app 编出的元数据对不上
@@ -7,4 +8,42 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.androidx.baselineprofile) apply false
+}
+
+val spotlessRatchetFrom =
+    providers.gradleProperty("spotlessRatchetFrom").orElse("origin/main")
+
+spotless {
+    // 旧代码不做一次性全量格式化，只检查相对基准提交变更过的文件。
+    ratchetFrom(spotlessRatchetFrom.get())
+
+    val excludedPaths = listOf(
+        "**/build/**",
+        ".gradle/**",
+        ".kotlin/**",
+        ".maafw/**",
+        ".worktree/**"
+    )
+    val ktlintEditorConfigOverride = mapOf(
+        "ktlint_standard_backing-property-naming" to "disabled",
+        "ktlint_standard_filename" to "disabled",
+        "ktlint_standard_function-naming" to "disabled",
+        "ktlint_standard_kdoc" to "disabled",
+        "ktlint_standard_max-line-length" to "disabled",
+        "ktlint_standard_property-naming" to "disabled",
+        "ktlint_standard_value-parameter-comment" to "disabled"
+    )
+
+    kotlin {
+        ktlint("1.8.0")
+            .editorConfigOverride(ktlintEditorConfigOverride)
+        target("**/*.kt")
+        targetExclude(*excludedPaths.toTypedArray())
+    }
+    kotlinGradle {
+        ktlint("1.8.0")
+            .editorConfigOverride(ktlintEditorConfigOverride)
+        target("**/*.gradle.kts")
+        targetExclude(*excludedPaths.toTypedArray())
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,13 +10,7 @@ plugins {
     alias(libs.plugins.androidx.baselineprofile) apply false
 }
 
-val spotlessRatchetFrom =
-    providers.gradleProperty("spotlessRatchetFrom").orElse("origin/main")
-
 spotless {
-    // 旧代码不做一次性全量格式化，只检查相对基准提交变更过的文件。
-    ratchetFrom(spotlessRatchetFrom.get())
-
     val excludedPaths = listOf(
         "**/build/**",
         ".gradle/**",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "9.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.9"
+spotless = "7.2.1"
 kotlinpoet = "2.3.0"
 snakeyamlEngine = "2.9"
 floatingX = "2.3.7"
@@ -139,3 +140,4 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxBenchmark" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/ksp-processor/src/main/kotlin/com/aliothmoon/preferences/processor/CodeGenerator.kt
+++ b/ksp-processor/src/main/kotlin/com/aliothmoon/preferences/processor/CodeGenerator.kt
@@ -6,8 +6,22 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.writeTo
 
 class SchemaCodeGenerator(


### PR DESCRIPTION
- 移除 Spotless ratchet，改为全量格式化检查
- Format workflow 改为执行 spotlessApply 并将 Kotlin 格式化结果写回当前分支
- PR 场景 checkout 真实 head branch，避免把 merge ref 推回源分支