### PR TITLE
fix: 跨执行轮次的运行日志错乱

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/di/RunnerModule.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/di/RunnerModule.kt
@@ -105,7 +105,7 @@ val runnerModule = module {
     single<RunScreenSaver> {
         val manager = get<ScreenSaverOverlayManager>()
         object : RunScreenSaver {
-            override suspend fun show(): Boolean = manager.show()
+            override suspend fun show(executionId: String?): Boolean = manager.show(executionId)
             override suspend fun hide() = manager.hide()
         }
     }

--- a/app/src/main/java/com/aliothmoon/maafw/notification/RunProgressSnapshot.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/notification/RunProgressSnapshot.kt
@@ -43,7 +43,12 @@ object RunProgressSnapshots {
         val done = execution?.completedTaskCount?.coerceIn(0, total) ?: 0
         val indeterminate = phase == RunnerPhase.Preparing || total <= 0
         val progressLabel = "$done/$total".takeIf { total > 0 }
-        val taskLabel = execution?.currentTaskLabel
+        val taskLabel = execution?.let { current ->
+            current.currentTaskLabel?.takeIf(String::isNotBlank)
+                ?: current.currentTaskName?.let { name ->
+                    current.taskLabels[name]?.takeIf(String::isNotBlank) ?: name
+                }
+        }
         val status = firstLine(statusText)?.takeIf { it != taskLabel && it != progressLabel }
         return RunProgressSnapshot(
             title = title,

--- a/app/src/main/java/com/aliothmoon/maafw/overlay/screensaver/ScreenSaverOverlayManager.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/overlay/screensaver/ScreenSaverOverlayManager.kt
@@ -53,6 +53,7 @@ class ScreenSaverOverlayManager(
     private var composeView: ComposeView? = null
     private var phaseJob: Job? = null
     private var logJob: Job? = null
+    private var boundExecutionId: String? = null
 
     private val _isShowing = MutableStateFlow(false)
     val isShowing: StateFlow<Boolean> = _isShowing.asStateFlow()
@@ -85,7 +86,9 @@ class ScreenSaverOverlayManager(
                 when {
                     // 开关只管「自动盖」；手动盖上的那次不受它影响
                     !previous.isBusy && current.isBusy ->
-                        if (appSettings.screenSaverEnabled.value) show()
+                        if (appSettings.screenSaverEnabled.value) {
+                            show(state.activeExecution?.executionId)
+                        }
 
                     // 结束就撤，别让用户回来面对一块黑屏还得先滑一下
                     previous.isBusy && !current.isBusy -> hide()
@@ -103,8 +106,13 @@ class ScreenSaverOverlayManager(
     // ── 显隐 ──
 
     /** 返回是否真的盖上了；没有悬浮窗权限时 addView 会抛，这里吞掉并如实回 false */
-    suspend fun show(): Boolean = withContext(Dispatchers.Main.immediate) {
-        if (_isShowing.value) return@withContext true
+    suspend fun show(executionId: String? = null): Boolean = withContext(Dispatchers.Main.immediate) {
+        val binding = executionId ?: runnerPort.state.value.activeExecution?.executionId
+        if (_isShowing.value) {
+            boundExecutionId = binding
+            startLogRelay()
+            return@withContext true
+        }
         if (appSettings.runMode.value != RunMode.BACKGROUND) {
             Timber.w("Not in background mode; ignoring screen-saver show request")
             return@withContext false
@@ -114,6 +122,7 @@ class ScreenSaverOverlayManager(
         runCatching { windowManager.addView(view, createLayoutParams()) }
             .onSuccess {
                 composeView = view
+                boundExecutionId = binding
                 viewModelOwner.start()
                 startLogRelay()
                 _isShowing.value = true
@@ -124,14 +133,16 @@ class ScreenSaverOverlayManager(
     }
 
     suspend fun hide() = withContext(Dispatchers.Main.immediate) {
-        val view = composeView ?: return@withContext
+        val view = composeView
         composeView = null
+        boundExecutionId = null
         _isShowing.value = false
         logJob?.cancel()
         logJob = null
         // 清掉，否则下一轮盖上的瞬间显示的是上一轮的尾句
         latestLog.value = null
         viewModelOwner.stop()
+        if (view == null) return@withContext
         runCatching { windowManager.removeView(view) }
             .onSuccess { Timber.d("Screen saver dismissed") }
             .onFailure { Timber.e(it, "Failed to remove screen saver") }
@@ -140,7 +151,13 @@ class ScreenSaverOverlayManager(
     private fun startLogRelay() {
         logJob?.cancel()
         logJob = scope.launch {
-            runnerPort.events.collect { latestLog.value = it.toLogText() }
+            runnerPort.events.collect { envelope ->
+                if (boundExecutionId == envelope.executionId) {
+                    envelope.event.toLogText().takeIf(String::isNotBlank)?.let {
+                        latestLog.value = it
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunner.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunner.kt
@@ -26,7 +26,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.io.File
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * 特权进程内的 MaaFramework 执行器
@@ -40,11 +39,12 @@ class MaaRunner(private val agentHost: AgentHost) {
         Thread(r, "maa-runner").apply { isDaemon = true }
     }
 
+    private val callbackDispatcher = MaaRunnerCallbackDispatcher()
+
     /** Binder stop can arrive while the worker is still preparing native handles. */
     private val lifecycleLock = Any()
     private var running = false
     private var stopRequested = false
-    private val callbackRef = AtomicReference<IMaaRunnerCallback?>()
 
     // native handle
     private var resource: Pointer? = null
@@ -79,16 +79,15 @@ class MaaRunner(private val agentHost: AgentHost) {
     /** JNA 回调必须被强引用住，否则会被 GC，native 回调时踩空 */
     private val eventSink = MaaFrameworkLibrary.MaaEventCallback { _, message, detailsJson, _ ->
         Ln.i("MaaEventCallback on $message")
-        runCatching {
-            callbackRef.get()?.onEvent(message.orEmpty(), detailsJson.orEmpty())
-        }.onFailure {
-            // 回调穿回 native 会直接崩进程
-            Ln.w("MaaRunner: event dispatch failed: ${it.message}")
+        // Native callback threads must not block on Binder. Queue the event, then deliver all
+        // runner callbacks from one thread so the terminal event cannot overtake queued raw data.
+        callbackDispatcher.dispatch {
+            onEvent(message.orEmpty(), detailsJson.orEmpty())
         }
     }
 
     fun setCallback(callback: IMaaRunnerCallback?) {
-        callbackRef.set(callback)
+        callbackDispatcher.setCallback(callback)
     }
 
     /** agent child 的一行输出；由 [AgentHost] 的泵线程调用，app 侧不在时静默丢弃 */
@@ -201,6 +200,7 @@ class MaaRunner(private val agentHost: AgentHost) {
 
     fun destroy() {
         worker.shutdownNow()
+        callbackDispatcher.close()
         releaseNative()
     }
 
@@ -261,11 +261,13 @@ class MaaRunner(private val agentHost: AgentHost) {
             reason = "${e.javaClass.simpleName}: ${e.message}"
             Ln.e("MaaRunner: run failed: $reason")
         } finally {
+            // Keep this run marked as running until its terminal Binder call has been sent.
+            // This is the ordering barrier for raw events already queued by the same execution.
+            notify(waitForDispatch = true) { onFinished(outcome, reason) }
             synchronized(lifecycleLock) {
                 running = false
                 stopRequested = false
             }
-            notify { onFinished(outcome, reason) }
         }
     }
 
@@ -543,10 +545,15 @@ class MaaRunner(private val agentHost: AgentHost) {
         loadedResourcePaths = emptyList()
     }
 
-    private inline fun notify(block: IMaaRunnerCallback.() -> Unit) {
-        val callback = callbackRef.get() ?: return
-        runCatching { callback.block() }
-            .onFailure { Ln.w("MaaRunner: callback failed: ${it.message}") }
+    private fun notify(
+        waitForDispatch: Boolean = false,
+        block: IMaaRunnerCallback.() -> Unit,
+    ) {
+        if (waitForDispatch) {
+            callbackDispatcher.dispatchAndAwait(block)
+        } else {
+            callbackDispatcher.dispatch(block)
+        }
     }
 
     private fun statusText(status: Int): String = when (status) {

--- a/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunnerCallbackDispatcher.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunnerCallbackDispatcher.kt
@@ -1,0 +1,68 @@
+package com.aliothmoon.maafw.remote
+
+import com.aliothmoon.maafw.IMaaRunnerCallback
+import com.aliothmoon.maafw.third.Ln
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.RejectedExecutionException
+
+/**
+ * Serializes callback delivery inside the privileged process.
+ *
+ * Native event callbacks and runner-worker callbacks otherwise travel over separate oneway
+ * Binder paths. In particular, onFinished can overtake a Tasker failure and make the app close
+ * its log session before the failure arrives. Every invocation captures the callback that was
+ * registered when the event was queued, so an old event cannot be delivered to a new execution.
+ */
+internal class MaaRunnerCallbackDispatcher(
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "maa-runner-callback").apply { isDaemon = true }
+    },
+) : AutoCloseable {
+
+    @Volatile
+    private var callback: IMaaRunnerCallback? = null
+
+    fun setCallback(callback: IMaaRunnerCallback?) {
+        this.callback = callback
+    }
+
+    fun dispatch(block: IMaaRunnerCallback.() -> Unit) {
+        enqueue(block, awaitDispatch = false)
+    }
+
+    /**
+     * Used for the run terminal callback. Waiting until the Binder invocation has been sent
+     * prevents MaaRunner from accepting the next run before all previously queued raw events
+     * have at least entered the same callback stream.
+     */
+    fun dispatchAndAwait(block: IMaaRunnerCallback.() -> Unit) {
+        enqueue(block, awaitDispatch = true)
+    }
+
+    private fun enqueue(block: IMaaRunnerCallback.() -> Unit, awaitDispatch: Boolean) {
+        val receiver = callback ?: return
+        val dispatch: Future<*> = try {
+            executor.submit {
+                runCatching { receiver.block() }
+                    .onFailure { Ln.w("MaaRunner: callback failed: ${it.message}") }
+            }
+        } catch (e: RejectedExecutionException) {
+            Ln.w("MaaRunner: callback rejected: ${e.message}")
+            return
+        }
+        if (!awaitDispatch) return
+        try {
+            dispatch.get()
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } catch (e: Exception) {
+            Ln.w("MaaRunner: terminal callback wait failed: ${e.message}")
+        }
+    }
+
+    override fun close() {
+        executor.shutdownNow()
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/runner/EnvironmentHooks.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/EnvironmentHooks.kt
@@ -121,8 +121,8 @@ class ScreenSaverHook(
         if (!settings.screenSaverEnabled.value) return EngageResult.Skipped()
 
         // 只有确实是本轮盖上的才登记撤销：用户自己手动盖的那份不归这一轮管
-        if (!screenSaver.show()) {
-            ctx.journal.warn(uiTextOf(R.string.run_log_screen_saver_skipped))
+        if (!screenSaver.show(ctx.executionId)) {
+            ctx.journal.warn(ctx.executionId, uiTextOf(R.string.run_log_screen_saver_skipped))
             return EngageResult.Skipped()
         }
         return EngageResult.Engaged(Release { screenSaver.hide() })
@@ -183,10 +183,16 @@ class AutoSleepHook(private val servicePort: PrivilegedServicePort) : RunEnvHook
         return EngageResult.Engaged(Release { reason ->
             when {
                 reason !is RunEndReason.Ran ->
-                    ctx.journal.info(uiTextOf(R.string.run_log_auto_sleep_skipped_not_run))
+                    ctx.journal.info(
+                        ctx.executionId,
+                        uiTextOf(R.string.run_log_auto_sleep_skipped_not_run),
+                    )
 
                 skipIfAwake && !tookOverIdleDevice ->
-                    ctx.journal.info(uiTextOf(R.string.run_log_auto_sleep_skipped_awake))
+                    ctx.journal.info(
+                        ctx.executionId,
+                        uiTextOf(R.string.run_log_auto_sleep_skipped_awake),
+                    )
 
                 else -> servicePort.callOrDefault("lockAndSleep", WakeUnlockResult.IPC_FAILED) {
                     it.lockAndSleep()
@@ -249,6 +255,6 @@ object CountdownHook : RunEnvHook {
  */
 interface RunScreenSaver {
     /** 返回是否确实由本次调用盖上 */
-    suspend fun show(): Boolean
+    suspend fun show(executionId: String?): Boolean
     suspend fun hide()
 }

--- a/app/src/main/java/com/aliothmoon/maafw/runner/FocusDispatcher.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/FocusDispatcher.kt
@@ -25,9 +25,20 @@ import kotlinx.coroutines.launch
 class FocusDispatcher(
     private val projectRepository: ProjectRepository,
     private val resolver: FocusContentResolver,
-    runnerPort: RunnerPort,
+    private val runnerPort: RunnerPort,
     scope: CoroutineScope,
 ) {
+
+    data class Dispatch(
+        val executionId: String,
+        val focus: FocusMessage,
+    )
+
+    /** Recorder 专用流：Message 与 Drained 保序，Drained 表示之前的 Message 已全部入流 */
+    sealed interface RecordingEvent {
+        data class Message(val dispatch: Dispatch) : RecordingEvent
+        data class Drained(val executionId: String) : RecordingEvent
+    }
 
     /**
      * 补完后的模板消息
@@ -35,32 +46,70 @@ class FocusDispatcher(
      * SharedFlow 而不是 StateFlow：这些是一次性消息，订阅者晚到不该补看上一条。
      * 容量给足 32——补完带 IO，慢订阅者不该把消息挤掉
      */
-    private val _resolved = MutableSharedFlow<FocusMessage>(
+    private val _resolved = MutableSharedFlow<Dispatch>(
         extraBufferCapacity = 32,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-    val resolved: Flow<FocusMessage> = _resolved.asSharedFlow()
+    val resolved: Flow<Dispatch> = _resolved.asSharedFlow()
+
+    private val _recording = MutableSharedFlow<RecordingEvent>(
+        extraBufferCapacity = 32,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /**
+     * 日志不能同时订阅 resolved 与另一个独立 terminal 流：两个 SharedFlow 到达 recorder
+     * 的顺序没有保证。这里用单流保序，Drained 只有在之前的 Message emit 完才会发出。
+     */
+    val recording: Flow<RecordingEvent> = _recording.asSharedFlow()
 
     /**
      * `trace` 命中的条目，未补完
      *
      * 上报侧要的是事件名与节点名，正文一概不带：PI 可以把用户输入拼进 focus 正文
      */
-    private val _traced = MutableSharedFlow<FocusMessage>(
+    private val _traced = MutableSharedFlow<Dispatch>(
         extraBufferCapacity = 32,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-    val traced: Flow<FocusMessage> = _traced.asSharedFlow()
+    val traced: Flow<Dispatch> = _traced.asSharedFlow()
 
     init {
         scope.launch {
-            runnerPort.events.collect { event ->
-                if (event !is RunnerEvent.Focus) return@collect
-                val focus = event.focus
-                if (focus.trace) _traced.emit(focus)
-                if (focus.displayable) _resolved.emit(complete(focus))
+            runnerPort.events.collect { envelope ->
+                if (envelope.event is RunnerEvent.ExecutionFinished) {
+                    // Drained carries no user-visible stale content; it only unblocks that
+                    // execution's recorder session. A newer run must not suppress it.
+                    _recording.emit(RecordingEvent.Drained(envelope.executionId))
+                    return@collect
+                }
+
+                val event = envelope.event as? RunnerEvent.Focus ?: return@collect
+                if (!accepts(envelope.executionId)) return@collect
+                val dispatch = Dispatch(envelope.executionId, event.focus)
+                val completed = if (event.focus.displayable) {
+                    dispatch.copy(focus = complete(event.focus))
+                } else {
+                    null
+                }
+                // IO 期间下一轮可能已经开始；补完结果不能再回到旧消费者面前
+                if (!accepts(envelope.executionId)) return@collect
+                if (event.focus.trace) _traced.emit(dispatch)
+                if (completed != null) {
+                    _resolved.emit(completed)
+                    _recording.emit(RecordingEvent.Message(completed))
+                }
             }
         }
+    }
+
+    private fun accepts(executionId: String): Boolean {
+        val state = runnerPort.state.value
+        val active = state.activeExecution
+        if (active != null) return active.executionId == executionId
+
+        val latest = state.latestExecutionId
+        return latest == null || latest == executionId
     }
 
     private suspend fun complete(focus: FocusMessage): FocusMessage {

--- a/app/src/main/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPort.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPort.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
-import java.util.UUID
 
 /**
  * RunnerPort 的真实实现：本对象跑在 app 进程，MaaFramework 实例在特权进程里，两者经 binder 通信
@@ -60,11 +59,11 @@ class MaaFrameworkRunnerPort(
     private val _state = MutableStateFlow(RunnerState())
     override val state: StateFlow<RunnerState> = _state.asStateFlow()
 
-    private val _events = MutableSharedFlow<RunnerEvent>(
+    private val _events = MutableSharedFlow<RunnerEventEnvelope>(
         extraBufferCapacity = 256,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-    override val events: Flow<RunnerEvent> = _events.asSharedFlow()
+    override val events: Flow<RunnerEventEnvelope> = _events.asSharedFlow()
 
     init {
         // 特权进程死了 onFinished 就永远不会来，phase 卡在 Running，configurationLocked
@@ -122,6 +121,7 @@ class MaaFrameworkRunnerPort(
             } else {
                 RunnerState(
                     phase = RunnerPhase.Idle,
+                    latestExecutionId = current.activeExecution?.executionId,
                     latestResult = ExecutionResult.Failed(
                         resultReason,
                         current.activeExecution?.taskResults.orEmpty(),
@@ -129,48 +129,109 @@ class MaaFrameworkRunnerPort(
                 )
             }
         }
-        if (previous.phase.isBusy) Timber.w(logMessage)
+        if (previous.phase.isBusy) {
+            previous.activeExecution?.let { execution ->
+                _events.tryEmit(
+                    RunnerEventEnvelope(
+                        executionId = execution.executionId,
+                        currentTaskName = execution.currentTaskName,
+                        currentTaskLabel = execution.currentTaskLabel,
+                        event = RunnerEvent.ExecutionFinished,
+                    ),
+                )
+            }
+            Timber.w(logMessage)
+        }
     }
 
     /**
      * JVM 单测里 [IMaaRunnerCallback.Stub] 会调未 mock 的 Binder.attachInterface
      * 测 start/stop/对账时换成空操作，避免为测 phase 去构造 AIDL Stub
      */
-    internal var bindRunnerCallback: (RemoteService) -> Unit = { service ->
-        service.setRunnerCallback(callback)
+    internal var bindRunnerCallback: (RemoteService, ExecutionCallback) -> Unit = { service, callback ->
+        service.setRunnerCallback(
+            object : IMaaRunnerCallback.Stub() {
+                override fun onEvent(message: String?, detailsJson: String?) =
+                    callback.onEvent(message, detailsJson)
+
+                override fun onAgentOutput(line: String?, fromStderr: Boolean) =
+                    callback.onAgentOutput(line, fromStderr)
+
+                override fun onAgentConnected(index: Int, total: Int, exec: String?) =
+                    callback.onAgentConnected(index, total, exec)
+
+                override fun onTaskStarted(taskName: String?, index: Int, total: Int) =
+                    callback.onTaskStarted(taskName, index, total)
+
+                override fun onTaskFinished(taskName: String?, success: Boolean, message: String?) =
+                    callback.onTaskFinished(taskName, success, message)
+
+                override fun onFinished(outcome: Int, reason: String?) =
+                    callback.onFinished(outcome, reason)
+            },
+        )
     }
 
-    private val callback by lazy { object : IMaaRunnerCallback.Stub() {
-        override fun onEvent(message: String?, detailsJson: String?) {
-            _events.tryEmit(toRunnerEvent(message.orEmpty(), detailsJson.orEmpty()))
+    /**
+     * Binder callback 是全局注册的；这个处理器按轮创建，晚到的旧调用仍带旧身份，
+     * 但不能再改写当前轮的 ActiveExecution
+     */
+    internal inner class ExecutionCallback(
+        private val executionId: String,
+        plan: RunPlan,
+    ) {
+        private val tasks = plan.tasks
+
+        @Volatile
+        private var currentTaskName: String? = null
+
+        @Volatile
+        private var currentTaskLabel: String? = null
+
+        private val isActive: Boolean
+            get() = _state.value.activeExecution?.executionId == executionId
+
+        fun onEvent(message: String?, detailsJson: String?) {
+            emit(toRunnerEvent(message.orEmpty(), detailsJson.orEmpty()))
         }
 
-        override fun onAgentOutput(line: String?, fromStderr: Boolean) {
-            _events.tryEmit(RunnerEvent.AgentOutput(line.orEmpty(), fromStderr))
+        fun onAgentOutput(line: String?, fromStderr: Boolean) {
+            emit(RunnerEvent.AgentOutput(line.orEmpty(), fromStderr))
         }
 
-        override fun onAgentConnected(index: Int, total: Int, exec: String?) {
-            _events.tryEmit(RunnerEvent.AgentConnected(index, total, exec.orEmpty()))
+        fun onAgentConnected(index: Int, total: Int, exec: String?) {
+            emit(RunnerEvent.AgentConnected(index, total, exec.orEmpty()))
         }
 
-        // 不碰 completedTaskCount：那是 onTaskFinished 的账，两边各记一套会在丢事件时永久漂
-        override fun onTaskStarted(taskName: String?, index: Int, total: Int) {
-            val name = taskName.orEmpty()
+        // index 是零基；回调名只作兜底，避免同名/别名抢错展示上下文
+        fun onTaskStarted(taskName: String?, index: Int, total: Int) {
+            val task = tasks.getOrNull(index) ?: tasks.firstOrNull { it.taskName == taskName.orEmpty() }
+            val name = task?.taskName ?: taskName.orEmpty()
+            val label = task?.label?.takeIf(String::isNotBlank) ?: name
+            currentTaskName = name
+            currentTaskLabel = label
+
+            // 不碰 completedTaskCount：那是 onTaskFinished 的账，两边各记一套会在丢事件时永久漂
             _state.update { current ->
+                val execution = current.activeExecution ?: return@update current
+                if (execution.executionId != executionId) return@update current
                 current.copy(
-                    activeExecution = current.activeExecution?.copy(
+                    activeExecution = execution.copy(
                         currentTaskName = name,
+                        currentTaskLabel = label,
                         totalTaskCount = total,
                     ),
                 )
             }
-            _events.tryEmit(RunnerEvent.Progress(name, index, total))
+            emit(RunnerEvent.Progress(name, index, total, label), currentTaskName = name)
         }
 
-        override fun onTaskFinished(taskName: String?, success: Boolean, message: String?) {
+        fun onTaskFinished(taskName: String?, success: Boolean, message: String?) {
+            if (!isActive) return
             val result = TaskResult(taskName.orEmpty(), success, message)
             _state.update { current ->
                 val execution = current.activeExecution ?: return@update current
+                if (execution.executionId != executionId) return@update current
                 val results = execution.taskResults + result
                 current.copy(
                     activeExecution = execution.copy(
@@ -181,40 +242,74 @@ class MaaFrameworkRunnerPort(
             }
         }
 
-        override fun onFinished(outcome: Int, reason: String?) {
-            val results = _state.value.activeExecution?.taskResults.orEmpty()
-            val result = when (outcome) {
-                RunOutcome.COMPLETED -> ExecutionResult.Completed(results)
-                RunOutcome.COMPLETED_WITH_FAILURES -> ExecutionResult.CompletedWithFailures(results)
-                RunOutcome.CANCELLED -> ExecutionResult.Cancelled(results)
-                else -> ExecutionResult.Failed(if (reason.isNullOrBlank()) uiTextOf(R.string.msg_fail_default) else uiTextFromFramework(reason), results)
+        fun onFinished(outcome: Int, reason: String?) {
+            if (!isActive) return
+            emit(RunnerEvent.ExecutionFinished)
+            _state.update { current ->
+                val execution = current.activeExecution ?: return@update current
+                if (execution.executionId != executionId) return@update current
+                val result = when (outcome) {
+                    RunOutcome.COMPLETED -> ExecutionResult.Completed(execution.taskResults)
+                    RunOutcome.COMPLETED_WITH_FAILURES -> ExecutionResult.CompletedWithFailures(execution.taskResults)
+                    RunOutcome.CANCELLED -> ExecutionResult.Cancelled(execution.taskResults)
+                    else -> ExecutionResult.Failed(
+                        if (reason.isNullOrBlank()) {
+                            uiTextOf(R.string.msg_fail_default)
+                        } else {
+                            uiTextFromFramework(reason)
+                        },
+                        execution.taskResults,
+                    )
+                }
+                RunnerState(
+                    phase = RunnerPhase.Idle,
+                    latestExecutionId = executionId,
+                    latestResult = result,
+                )
             }
-            _state.value = RunnerState(phase = RunnerPhase.Idle, latestResult = result)
         }
-    } }
 
-    override suspend fun start(plan: RunPlan): RunnerCommandResult {
+        private fun emit(
+            event: RunnerEvent,
+            currentTaskName: String? = this.currentTaskName,
+            currentTaskLabel: String? = this.currentTaskLabel,
+        ) {
+            _events.tryEmit(
+                RunnerEventEnvelope(
+                    executionId = executionId,
+                    currentTaskName = currentTaskName,
+                    currentTaskLabel = currentTaskLabel,
+                    event = event,
+                ),
+            )
+        }
+    }
+
+    override suspend fun start(plan: RunPlan, executionId: String): RunnerCommandResult {
         if (_state.value.phase.isBusy) {
             return RunnerCommandResult.Rejected(uiTextOf(R.string.msg_reject_already_running))
         }
-        val executionId = UUID.randomUUID().toString()
         _state.value = RunnerState(
             phase = RunnerPhase.Preparing,
             activeExecution = ActiveExecution(
                 executionId = executionId,
                 runConfigurationId = plan.runConfigurationId,
                 currentTaskName = null,
+                currentTaskLabel = null,
                 completedTaskCount = 0,
                 totalTaskCount = plan.tasks.size,
                 taskResults = emptyList(),
                 taskLabels = plan.taskLabelMap(),
             ),
+            latestExecutionId = executionId,
             latestResult = null,
         )
 
+        val callback = ExecutionCallback(executionId, plan)
+
         return withContext(MaaDispatchers.IO) {
             try {
-                val rejection = launchOnService(plan, executionId)
+                val rejection = launchOnService(plan, executionId, callback)
                 if (rejection != null) return@withContext failPreparation(rejection, executionId)
                 // Stop 可能在 Preparing 窗口里已经把 phase 打成 Stopping，甚至 onFinished 已收回 Idle
                 // 无条件写成 Running 会把停止意图丢掉，任务继续跑到结束
@@ -272,9 +367,13 @@ class MaaFrameworkRunnerPort(
      * 走 useService 而非取当前实例：它会先刷新授权状态、必要时发起授权请求，
      * 后端换了也会重新绑定
      */
-    private suspend fun launchOnService(plan: RunPlan, executionId: String): UiText? {
+    private suspend fun launchOnService(
+        plan: RunPlan,
+        executionId: String,
+        callback: ExecutionCallback,
+    ): UiText? {
         val piRoot = installer.installedDir()
-        return servicePort.useService { service -> prepareAndStart(plan, piRoot, service, executionId) }
+        return servicePort.useService { service -> prepareAndStart(plan, piRoot, service, executionId, callback) }
     }
 
     private fun prepareAndStart(
@@ -282,6 +381,7 @@ class MaaFrameworkRunnerPort(
         piRoot: File,
         service: RemoteService,
         executionId: String,
+        callback: ExecutionCallback,
     ): UiText? {
         if (!service.setup(piRoot.absolutePath, AppPaths.LOG_DIR.absolutePath, debugMode())) {
             return uiTextOf(R.string.msg_reject_setup_failed)
@@ -317,7 +417,7 @@ class MaaFrameworkRunnerPort(
             return if (mode == RunMode.FOREGROUND) uiTextOf(R.string.msg_reject_primary_capture) else uiTextOf(R.string.msg_reject_virtual_display)
         }
 
-        bindRunnerCallback(service)
+        bindRunnerCallback(service, callback)
 
         val payload = RunPlanPayload(
             resourcePaths = plan.resource.paths.map { File(piRoot, it).absolutePath },
@@ -358,11 +458,19 @@ class MaaFrameworkRunnerPort(
     private fun failPreparation(reason: UiText, executionId: String): RunnerCommandResult {
         val next = _state.updateAndGet { current ->
             if (current.phase == RunnerPhase.Preparing) {
-                RunnerState(phase = RunnerPhase.Idle, latestResult = ExecutionResult.Failed(reason))
+                RunnerState(
+                    phase = RunnerPhase.Idle,
+                    latestExecutionId = executionId,
+                    latestResult = ExecutionResult.Failed(reason),
+                )
             } else if (current.phase == RunnerPhase.Stopping &&
                 current.activeExecution?.executionId == executionId
             ) {
-                RunnerState(phase = RunnerPhase.Idle, latestResult = ExecutionResult.Cancelled(emptyList()))
+                RunnerState(
+                    phase = RunnerPhase.Idle,
+                    latestExecutionId = executionId,
+                    latestResult = ExecutionResult.Cancelled(emptyList()),
+                )
             } else {
                 current
             }

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunContext.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunContext.kt
@@ -76,6 +76,8 @@ fun interface RunProgress {
  * 在里面读到的就已经是冻结值，捕获进闭包即可；塞进来只会让本类随挂载物数量膨胀
  */
 class RunContext(
+    /** 一轮日志、状态机与迟到回调共用的身份；由编排层生成 */
+    val executionId: String = java.util.UUID.randomUUID().toString(),
     val trigger: RunTrigger,
     val runMode: RunMode,
     val plan: RunPlan,

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunJournal.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunJournal.kt
@@ -11,11 +11,15 @@ import com.aliothmoon.maafw.i18n.UiText
  */
 interface RunJournal {
 
-    suspend fun begin(plan: RunPlan)
+    suspend fun begin(plan: RunPlan, executionId: String)
 
-    suspend fun end(reason: RunEndReason)
+    suspend fun end(executionId: String, reason: RunEndReason)
 
-    fun note(level: RunNote, text: UiText)
+    /** 生产会话日志用：先等事件流终局被消费，再写 Footer 并关文件 */
+    suspend fun endAfterDrain(executionId: String, reason: RunEndReason) =
+        end(executionId, reason)
+
+    fun note(executionId: String, level: RunNote, text: UiText)
 }
 
 /** 外壳自产行的级别；与 MXU 回调那套 [RunLogKind] 分开，避免 hook 去选 Verbose / Agent */
@@ -25,15 +29,18 @@ enum class RunNote {
     Error,
 }
 
-fun RunJournal.info(text: UiText) = note(RunNote.Info, text)
+fun RunJournal.info(executionId: String, text: UiText) =
+    note(executionId, RunNote.Info, text)
 
-fun RunJournal.warn(text: UiText) = note(RunNote.Warning, text)
+fun RunJournal.warn(executionId: String, text: UiText) =
+    note(executionId, RunNote.Warning, text)
 
-fun RunJournal.error(text: UiText) = note(RunNote.Error, text)
+fun RunJournal.error(executionId: String, text: UiText) =
+    note(executionId, RunNote.Error, text)
 
 /** 单测与没有落盘的调用方 */
 object DiscardingRunJournal : RunJournal {
-    override suspend fun begin(plan: RunPlan) = Unit
-    override suspend fun end(reason: RunEndReason) = Unit
-    override fun note(level: RunNote, text: UiText) = Unit
+    override suspend fun begin(plan: RunPlan, executionId: String) = Unit
+    override suspend fun end(executionId: String, reason: RunEndReason) = Unit
+    override fun note(executionId: String, level: RunNote, text: UiText) = Unit
 }

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunLauncher.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunLauncher.kt
@@ -144,7 +144,16 @@ class RunLauncher(
                 is RunPlanResult.Success -> built.plan
             }
 
-            val ctx = RunContext(trigger, runMode(), plan, acknowledged, signals, progress, journal)
+            val ctx = RunContext(
+                executionId = java.util.UUID.randomUUID().toString(),
+                trigger = trigger,
+                runMode = runMode(),
+                plan = plan,
+                acknowledged = acknowledged,
+                signals = signals,
+                progress = progress,
+                journal = journal,
+            )
             runPrechecks(ctx)?.let { return it }
 
             if (force) preemptRunning()
@@ -154,7 +163,7 @@ class RunLauncher(
                 return RunLaunchResult.Blocked(halt.reason)
             }
 
-            when (val command = runnerPort.start(plan)) {
+            when (val command = runnerPort.start(plan, ctx.executionId)) {
                 RunnerCommandResult.Accepted -> Unit
                 is RunnerCommandResult.Rejected -> {
                     finalize(engaged, RunEndReason.NotRun(NotRunCause.Rejected))

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunLog.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunLog.kt
@@ -67,8 +67,9 @@ private val NON_ESSENTIAL_KINDS =
 
 /** 屏保那一行只要一句话，带上 details_json 就糊了 */
 fun RunnerEvent.toLogText(): String = when (this) {
+    is RunnerEvent.ExecutionFinished -> ""
     is RunnerEvent.Log -> message
-    is RunnerEvent.Progress -> "$taskName $completed/$total"
+    is RunnerEvent.Progress -> "${taskLabel ?: taskName} $completed/$total"
     is RunnerEvent.Focus -> focus.content
     is RunnerEvent.AgentOutput -> line
     is RunnerEvent.AgentConnected -> label

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunLogComposer.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunLogComposer.kt
@@ -39,11 +39,13 @@ class RunLogComposer {
     /** 返回 null 表示这条不展示（被去重掉，或洪泛期的 agent 输出） */
     fun compose(event: RunnerEvent, id: Long, atMillis: Long, context: RunLogContext): RunLogEntry? {
         val composed = when (event) {
+            is RunnerEvent.ExecutionFinished -> return null
+
             is RunnerEvent.Log -> Composed(RunLogKind.Info, uiTextFromFramework(event.message))
 
             is RunnerEvent.Progress -> Composed(
                 RunLogKind.Info,
-                uiTextFromFramework("${event.taskName} ${event.completed}/${event.total}"),
+                uiTextFromFramework("${event.taskLabel ?: event.taskName} ${event.completed}/${event.total}"),
             )
 
             // 正文已由调用方补完（$i18n 查表、{image}、文件路径），这里只负责装进条目：
@@ -185,21 +187,26 @@ class RunLogComposer {
     }
 }
 
-/**
- * 合成一行人话需要的、Runner 给不出的那些东西
- *
- * [currentTaskName] 取自 `ActiveExecution.currentTaskLabel`：给人看的展示名，
- * 不是内部 `taskName`。MXU 靠 `task_id → selectedTaskId` 的映射表回认；
- * 我们串行投递、同时只有一个任务在跑，当前任务本身就是权威，不必再建一张表
- */
+/** 合成一行人话需要的、Runner 给不出的那些东西 */
 data class RunLogContext(
     val currentTaskName: String? = null,
+    /** Runner 在事件产生时冻下的展示名；回调缺 entry 且任务名不在本轮映射时兜底 */
+    val currentTaskLabel: String? = null,
+    /** 内部任务名到展示名；只在回调缺 entry 时兜底 */
+    val taskLabels: Map<String, String> = emptyMap(),
+    /** Tasker 回调 entry 到展示名；与任务名是两个 key 空间 */
+    val entryLabels: Map<String, String> = emptyMap(),
     val resourceLabel: String? = null,
 ) {
-    /** 拿不到当前任务名就退回 PI 的 entry：宁可显示内部名，也不显示空 */
+    /**
+     * Tasker 回调自带 entry；不能依赖 currentTaskName，因为异步日志消费可能晚于
+     * 下一个任务的 onTaskStarted，把旧任务的结果标成新任务。
+     */
     fun taskLabel(details: JsonObject?): String =
-        currentTaskName?.takeIf { it.isNotBlank() }
-            ?: details.string("entry")
+        details.string("entry")
+            ?.let { entryLabels[it]?.takeIf(String::isNotBlank) ?: it }
+            ?: currentTaskLabel?.takeIf(String::isNotBlank)
+            ?: currentTaskName?.let { taskLabels[it]?.takeIf(String::isNotBlank) ?: it }
             ?: UNKNOWN_SUBJECT
 
     /** 一轮只加载一个 resource 的若干路径，用它的展示名比逐条报绝对路径有用 */

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunLogRecorder.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunLogRecorder.kt
@@ -2,9 +2,10 @@ package com.aliothmoon.maafw.runner
 
 import com.aliothmoon.maafw.MaaDispatchers
 import com.aliothmoon.maafw.i18n.UiText
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,13 +13,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
@@ -28,8 +32,8 @@ import java.util.concurrent.atomic.AtomicReference
  * 进程级而非 Activity 级。原先合成在 `SessionViewModel` 里，切语言 Activity 一重建
  * 跑到一半的日志就没了；定时触发时更是压根没有 VM。屏保与前台服务也要读同一份
  *
- * 合成只在一条协程上跑（两条流先 merge 再收）：[RunLogComposer] 的去重与洪泛滑窗都是
- * 可变状态，两个收集器并发进去会把窗口算乱
+ * Runner / Focus / Clear 都汇到 `recorderInputs`，合成只在一条消费协程上跑：
+ * [RunLogComposer] 的去重与洪泛滑窗都是可变状态，多个收集器并发进去会把窗口算乱
  */
 class RunLogRecorder(
     private val runnerPort: RunnerPort,
@@ -58,17 +62,48 @@ class RunLogRecorder(
     private val _liveUpdateStatus = MutableStateFlow<String?>(null)
     val liveUpdateStatus: StateFlow<String?> = _liveUpdateStatus.asStateFlow()
 
-    private val composer = RunLogComposer()
     private val nextId = AtomicLong(0L)
 
-    /** 本轮的资源展示名，开会话时从 [RunPlan] 冻下来——运行中用户改了资源不该影响这一轮的正文 */
-    @Volatile
-    private var resourceLabel: String? = null
+    private data class ExecutionContext(
+        val taskLabels: Map<String, String>,
+        val entryLabels: Map<String, String>,
+        val resourceLabel: String?,
+        val composer: RunLogComposer,
+        val ended: AtomicBoolean = AtomicBoolean(false),
+    )
 
-    private val pending = ConcurrentLinkedQueue<RunSessionRecord.Line>()
-    private val session = AtomicReference<RunSessionWriter?>(null)
+    /** 迟到事件要带旧轮上下文进内存日志，不能借用当前轮映射 */
+    private val executionContexts = ConcurrentHashMap<String, ExecutionContext>()
+    private val executionOrder = ArrayDeque<String>()
+    private val executionOrderLock = Any()
+
+    /**
+     * 上下文 ring 只留 8 轮是为了限内存；已结束身份要留得更久，
+     * 否则极迟回调在上下文被逐出后又会被空闲期当成「无主事件」
+     */
+    private val endedExecutionIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    private val endedOrder = ArrayDeque<String>()
+
+    private class ActiveSession(
+        val executionId: String,
+        val writer: RunSessionWriter?,
+        val pending: ConcurrentLinkedQueue<RunSessionRecord.Line>,
+        val rawDrained: CompletableDeferred<Unit> = CompletableDeferred(),
+        val focusDrained: CompletableDeferred<Unit> = CompletableDeferred(),
+        val closed: AtomicBoolean = AtomicBoolean(false),
+    )
+
+    private sealed interface RecorderInput {
+        data class Runner(val envelope: RunnerEventEnvelope) : RecorderInput
+        data class Focus(val event: FocusDispatcher.RecordingEvent) : RecorderInput
+        data object Clear : RecorderInput
+    }
+
+    private val sessions = ConcurrentHashMap<String, ActiveSession>()
+    private val activeExecutionId = AtomicReference<String?>(null)
+    private val latestExecutionId = AtomicReference<String?>(null)
+    private val flushJobs = ConcurrentHashMap<String, Job>()
     private val fileLock = Mutex()
-    private var flushLoop: Job? = null
 
     /**
      * 屏上那份的环形缓冲；[note] 与合成协程两边都写，靠 [uiLock] 串起来
@@ -78,16 +113,24 @@ class RunLogRecorder(
     private val uiBuffer = ArrayDeque<RunLogEntry>(RUN_LOG_CAPACITY)
     private val uiLock = Any()
     private val uiDirty = Channel<Unit>(Channel.CONFLATED)
+    /** 所有日志输入都送这里；clear 也从 UI/调用方线程入队，不在写入方直接 reset composer */
+    private val recorderInputs = Channel<RecorderInput>(Channel.UNLIMITED)
 
     init {
         scope.launch {
-            merge(
-                // Focus 从 events 上过滤掉：它要先经 FocusDispatcher 补完（$i18n / 文件 / 占位符）
-                runnerPort.events.filter { it !is RunnerEvent.Focus },
-                focusDispatcher.resolved
-                    .filter { FocusChannel.Log in it.channels }
-                    .map { RunnerEvent.Focus(it) },
-            ).collect(::record)
+            // Focus 从 events 上过滤掉：它要先经 FocusDispatcher 补完（$i18n / 文件 / 占位符）
+            runnerPort.events
+                .filter { it.event !is RunnerEvent.Focus }
+                .map(RecorderInput::Runner)
+                .collect(recorderInputs::send)
+        }
+        scope.launch {
+            focusDispatcher.recording
+                .map(RecorderInput::Focus)
+                .collect(recorderInputs::send)
+        }
+        scope.launch {
+            while (true) record(recorderInputs.receive())
         }
         // 先发后等：第一条即时可见，随后那串攒成一次。等待期间来的由 CONFLATED 留到下一轮
         scope.launch {
@@ -101,21 +144,46 @@ class RunLogRecorder(
 
     /** 只清屏上这份，不动已落盘的历史——用户按的是「清空」不是「删记录」 */
     fun clear() {
-        composer.reset()
         synchronized(uiLock) { uiBuffer.clear() }
         _runLog.value = emptyList()
+        // composer 只在 recorder 协程里用；清屏会改去重状态，不能从 UI 线程直接 reset
+        recorderInputs.trySend(RecorderInput.Clear)
         // FGS 状态跟这一轮走，beginSession 才换句子
     }
 
-    override suspend fun begin(plan: RunPlan) = beginSession(plan)
+    override suspend fun begin(plan: RunPlan, executionId: String) = beginSession(plan, executionId)
 
-    override suspend fun end(reason: RunEndReason) = endSession(reason)
+    override suspend fun end(executionId: String, reason: RunEndReason) =
+        endSession(executionId, reason)
+
+    override suspend fun endAfterDrain(executionId: String, reason: RunEndReason) {
+        val active = sessions[executionId]
+        // NotRun 路径没有 Runner 终局 marker；立即收尾，避免每个被拒绝的请求白等一次超时
+        if (reason is RunEndReason.NotRun || active == null) {
+            endSession(executionId, reason)
+            return
+        }
+
+        try {
+            withTimeout(DRAIN_TIMEOUT_MS) {
+                active.rawDrained.await()
+                active.focusDrained.await()
+            }
+        } catch (timeout: TimeoutCancellationException) {
+            Timber.w(
+                "session log drain timed out after %dms: %s",
+                DRAIN_TIMEOUT_MS,
+                executionId,
+            )
+        }
+        endSession(executionId, reason)
+    }
 
     /**
      * 外壳自产的一行：不经过 [RunnerEvent]，不走合成器去重
      * 连续两句相同的警告多半是两处各自报的，丢掉会少现场
      */
-    override fun note(level: RunNote, text: UiText) {
+    override fun note(executionId: String, level: RunNote, text: UiText) {
         publish(
             RunLogEntry(
                 id = nextId.incrementAndGet(),
@@ -123,113 +191,205 @@ class RunLogRecorder(
                 kind = level.asRunLogKind(),
                 text = text,
             ),
+            executionId = executionId,
+            displayInUi = shouldDisplayInUi(executionId),
+            updateUserFacing = ownsActiveExecution(executionId),
+            updateLiveStatus = ownsActiveExecution(executionId),
         )
     }
 
     /**
      * 开一轮的会话文件
      *
-     * 顺带 [RunLogComposer.reset]：去重与洪泛滑窗是按轮的状态，跨轮留着会让新一轮
-     * 的第一条被上一轮的末条去重掉
+     * 每轮一个 composer 与映射：迟到旧事件可以进内存，但不能参与新一轮去重或落盘
      */
-    suspend fun beginSession(plan: RunPlan) {
-        resourceLabel = plan.resource.label
-        composer.reset()
+    suspend fun beginSession(plan: RunPlan, executionId: String) {
+        rememberExecutionContext(plan, executionId)
+        val active = ActiveSession(
+            executionId = executionId,
+            writer = store.open(System.currentTimeMillis(), plan.tasks.map { it.taskName }),
+            pending = ConcurrentLinkedQueue(),
+        )
+        sessions[executionId] = active
+        activeExecutionId.set(executionId)
+        latestExecutionId.set(executionId)
         resetLiveStatus()
-        val writer = store.open(System.currentTimeMillis(), plan.tasks.map { it.taskName })
-        fileLock.withLock { session.getAndSet(writer)?.close() }
-        if (writer == null) return
-        flushLoop = scope.launch(MaaDispatchers.IO) {
+        // 旧轮文件留给旧收尾协程 drain；这里只冻结 live 归属，不能提前关，
+        // 否则真的“上一轮失败但日志显示下轮失败”时队列里的失败行会被丢掉
+        rememberStaleExecutions(executionId)
+        if (active.writer == null) return
+        flushJobs[executionId] = scope.launch(MaaDispatchers.IO) {
             while (isActive) {
                 delay(FLUSH_INTERVAL_MS)
-                flushPending()
+                flushPending(active)
             }
         }
     }
 
-    suspend fun endSession(reason: RunEndReason) {
-        flushLoop?.cancel()
-        flushLoop = null
-        flushPending()
+    suspend fun endSession(executionId: String, reason: RunEndReason) {
+        executionContext(executionId).ended.set(true)
+        rememberEndedExecution(executionId)
+        activeExecutionId.compareAndSet(executionId, null)
+        flushJobs.remove(executionId)?.cancel()
+        val footer = RunSessionRecord.Footer(
+            endedAt = System.currentTimeMillis(),
+            outcome = reason.toSessionOutcome(),
+        )
         fileLock.withLock {
-            session.getAndSet(null)?.let { writer ->
-                writer.write(
-                    listOf(
-                        RunSessionRecord.Footer(
-                            endedAt = System.currentTimeMillis(),
-                            outcome = reason.toSessionOutcome(),
-                        ),
-                    ),
-                )
-                writer.close()
-            }
+            closeSession(sessions.remove(executionId), footer)
         }
-        resourceLabel = null
     }
 
-    private fun record(event: RunnerEvent) {
+    private fun rememberExecutionContext(plan: RunPlan, executionId: String) {
+        val context = ExecutionContext(
+            taskLabels = plan.taskLabelMap(),
+            entryLabels = plan.entryLabelMap(),
+            resourceLabel = plan.resource.label,
+            composer = RunLogComposer(),
+        )
+        synchronized(executionOrderLock) {
+            executionContexts[executionId] = context
+            executionOrder.remove(executionId)
+            executionOrder.addLast(executionId)
+            while (executionOrder.size > REMEMBERED_EXECUTIONS) {
+                executionContexts.remove(executionOrder.removeFirst())
+            }
+        }
+    }
+
+    private fun executionContext(executionId: String): ExecutionContext {
+        executionContexts[executionId]?.let { return it }
+        val created = ExecutionContext(emptyMap(), emptyMap(), null, RunLogComposer())
+        synchronized(executionOrderLock) {
+            executionContexts.putIfAbsent(executionId, created)?.let { return it }
+            executionOrder.remove(executionId)
+            executionOrder.addLast(executionId)
+            while (executionOrder.size > REMEMBERED_EXECUTIONS) {
+                executionContexts.remove(executionOrder.removeFirst())
+            }
+        }
+        return created
+    }
+
+    private fun record(input: RecorderInput) {
+        when (input) {
+            is RecorderInput.Runner -> record(input.envelope)
+            RecorderInput.Clear -> executionContexts.values.forEach { it.composer.reset() }
+            is RecorderInput.Focus ->
+                when (val event = input.event) {
+                    is FocusDispatcher.RecordingEvent.Message -> {
+                        val focus = event.dispatch.focus
+                        if (FocusChannel.Log in focus.channels) {
+                            record(
+                                RunnerEventEnvelope(
+                                    executionId = event.dispatch.executionId,
+                                    event = RunnerEvent.Focus(focus),
+                                ),
+                            )
+                        }
+                    }
+
+                    is FocusDispatcher.RecordingEvent.Drained ->
+                        sessions[event.executionId]?.focusDrained?.complete(Unit)
+                }
+        }
+    }
+
+    private fun record(envelope: RunnerEventEnvelope) {
+        val event = envelope.event
+        if (event is RunnerEvent.ExecutionFinished) {
+            sessions[envelope.executionId]?.rawDrained?.complete(Unit)
+            return
+        }
+        val belongsToActiveSession = ownsActiveExecution(envelope.executionId)
         when (event) {
             is RunnerEvent.Progress -> {
                 // Progress 行就是 contentText 的 done/total · label，再当 status 会叠一遍
-                _lastPipelineNode.value = null
-                _lastFocus.value = null
-                _liveUpdateStatus.value = null
+                if (belongsToActiveSession) {
+                    _lastPipelineNode.value = null
+                    _lastFocus.value = null
+                    _liveUpdateStatus.value = null
+                }
             }
             is RunnerEvent.Callback -> {
-                PipelineNodeStatus.nameOf(event.message, event.details)?.let {
-                    _lastPipelineNode.value = it
-                    refreshLiveStatus()
+                if (belongsToActiveSession) {
+                    PipelineNodeStatus.nameOf(event.message, event.details)?.let {
+                        _lastPipelineNode.value = it
+                        refreshLiveStatus()
+                    }
                 }
             }
             is RunnerEvent.Focus -> {
-                event.focus.content.lineSequence()
-                    .firstOrNull { it.isNotBlank() }
-                    ?.trim()
-                    ?.let {
-                        _lastFocus.value = it
-                        refreshLiveStatus()
-                    }
+                if (belongsToActiveSession) {
+                    event.focus.content.lineSequence()
+                        .firstOrNull { it.isNotBlank() }
+                        ?.trim()
+                        ?.let {
+                            _lastFocus.value = it
+                            refreshLiveStatus()
+                        }
+                }
             }
             else -> Unit
         }
-        val entry = composer.compose(
+        val context = executionContext(envelope.executionId)
+        val entry = context.composer.compose(
             event = event,
             id = nextId.incrementAndGet(),
             atMillis = System.currentTimeMillis(),
             context = RunLogContext(
-                currentTaskName = runnerPort.state.value.activeExecution?.currentTaskLabel,
-                resourceLabel = resourceLabel,
+                currentTaskName = envelope.currentTaskName,
+                currentTaskLabel = envelope.currentTaskLabel,
+                taskLabels = context.taskLabels,
+                entryLabels = context.entryLabels,
+                resourceLabel = context.resourceLabel,
             ),
-        ) ?: return
-        publish(entry, updateLiveStatus = event !is RunnerEvent.Progress)
+        )
+        if (entry == null) return
+        publish(
+            entry = entry,
+            executionId = envelope.executionId,
+            displayInUi = shouldDisplayInUi(envelope.executionId),
+            updateUserFacing = belongsToActiveSession,
+            updateLiveStatus = belongsToActiveSession && event !is RunnerEvent.Progress,
+        )
     }
 
-    private fun publish(entry: RunLogEntry, updateLiveStatus: Boolean = true) {
-        if (entry.isEssential) {
+    private fun publish(
+        entry: RunLogEntry,
+        executionId: String?,
+        displayInUi: Boolean,
+        updateUserFacing: Boolean,
+        updateLiveStatus: Boolean,
+    ) {
+        if (entry.isEssential && updateUserFacing) {
             renderText(entry.text).lineSequence()
                 .firstOrNull { it.isNotBlank() }
                 ?.trim()
                 ?.let {
                     _lastUserFacing.value = it
-                    if (updateLiveStatus) refreshLiveStatus()
                 }
+            if (updateLiveStatus) refreshLiveStatus()
         }
-        synchronized(uiLock) {
-            while (uiBuffer.size >= RUN_LOG_CAPACITY) uiBuffer.removeFirst()
-            uiBuffer.addLast(entry)
+        if (displayInUi) {
+            synchronized(uiLock) {
+                while (uiBuffer.size >= RUN_LOG_CAPACITY) uiBuffer.removeFirst()
+                uiBuffer.addLast(entry)
+            }
+            uiDirty.trySend(Unit)
         }
-        uiDirty.trySend(Unit)
 
-        // 没开会话就只留内存：会话之外的事件（比如空闲期的服务日志）不该凭空造出一个文件
-        if (session.get() == null) return
-        pending.add(
-            RunSessionRecord.Line(
-                atMillis = entry.atMillis,
-                kind = entry.kind,
-                text = renderText(entry.text),
-                detail = entry.detail?.takeIf { includeDetails() },
-            ),
+        val active = executionId?.let(sessions::get) ?: return
+        if (active.writer == null || active.closed.get()) return
+        val record = RunSessionRecord.Line(
+            atMillis = entry.atMillis,
+            kind = entry.kind,
+            text = renderText(entry.text),
+            detail = entry.detail?.takeIf { includeDetails() },
         )
+        active.pending.add(record)
+        // close 可能刚好和入队交错；复查失败时这条只留在内存，不能悄悄挂进已关闭的 session。
+        if (active.closed.get()) active.pending.remove(record)
     }
 
     private fun resetLiveStatus() {
@@ -238,6 +398,29 @@ class RunLogRecorder(
         _lastPipelineNode.value = null
         _liveUpdateStatus.value = null
     }
+
+    private fun ownsActiveExecution(executionId: String): Boolean =
+        when (val current = activeExecutionId.get()) {
+            null -> when {
+                executionId in endedExecutionIds -> false
+                else -> executionContexts[executionId]?.let { !it.ended.get() } ?: true
+            }
+            else -> current == executionId
+        }
+
+    /**
+     * UI 日志跟随当前轮：新轮开始后旧轮迟到事件不再插屏；
+     * 空闲期仍显示最近一轮的尾巴，收尾警告与终局后的迟到回调不该凭空消失。
+     * 从未开过轮时保持无主事件可见，兼容空闲期服务日志。
+     */
+    private fun shouldDisplayInUi(executionId: String): Boolean =
+        when (val current = activeExecutionId.get()) {
+            null -> when (val latest = latestExecutionId.get()) {
+                null -> true
+                else -> latest == executionId
+            }
+            else -> current == executionId
+        }
 
     private fun refreshLiveStatus() {
         _liveUpdateStatus.value = resolveLiveUpdateStatus(
@@ -252,16 +435,47 @@ class RunLogRecorder(
     }
 
     /** 攒批落盘；整批只 flush 一次 */
-    private suspend fun flushPending() {
-        if (pending.isEmpty()) return
+    private suspend fun flushPending(active: ActiveSession? = null) {
+        val target = active ?: return
+        if (target.pending.isEmpty()) return
         withContext(MaaDispatchers.IO) {
             fileLock.withLock {
-                val writer = session.get() ?: return@withLock
+                if (target.closed.get()) return@withLock
                 // poll 到空而不是 toList()+clear()：后者会和并发入队抢，中间那几条直接丢
                 val batch = buildList {
-                    while (true) add(pending.poll() ?: break)
+                    while (true) add(target.pending.poll() ?: break)
                 }
-                writer.write(batch)
+                target.writer?.write(batch)
+            }
+        }
+    }
+
+    private fun closeSession(active: ActiveSession?, footer: RunSessionRecord.Footer?) {
+        if (active == null || !active.closed.compareAndSet(false, true)) return
+        active.rawDrained.complete(Unit)
+        active.focusDrained.complete(Unit)
+        val writer = active.writer ?: return
+        val records = buildList {
+            while (true) add(active.pending.poll() ?: break)
+            footer?.let { add(it) }
+        }
+        writer.write(records)
+        writer.close()
+    }
+
+    private fun rememberStaleExecutions(executionId: String) {
+        sessions.keys.filterNot { it == executionId }.forEach {
+            executionContexts[it]?.ended?.set(true)
+            rememberEndedExecution(it)
+        }
+    }
+
+    private fun rememberEndedExecution(executionId: String) {
+        synchronized(executionOrderLock) {
+            if (!endedExecutionIds.add(executionId)) return
+            endedOrder.addLast(executionId)
+            while (endedOrder.size > ENDED_EXECUTIONS) {
+                endedExecutionIds.remove(endedOrder.removeFirst())
             }
         }
     }
@@ -269,6 +483,9 @@ class RunLogRecorder(
     private companion object {
         /** 与 MaaMeow 的 `LOG_FLUSH_INTERVAL_MS` 同值：够把一串突发攒成一次写 */
         const val FLUSH_INTERVAL_MS = 75L
+        const val DRAIN_TIMEOUT_MS = 2_000L
+        const val REMEMBERED_EXECUTIONS = 8
+        const val ENDED_EXECUTIONS = 64
     }
 }
 

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunPlan.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunPlan.kt
@@ -29,5 +29,13 @@ data class RuntimeTask(
     val label: String = taskName,
 )
 
-fun RunPlan.taskLabelMap(): Map<String, String> =
-    tasks.associate { it.taskName to it.label.ifBlank { it.taskName } }
+private fun List<RuntimeTask>.labelsBy(keyOf: (RuntimeTask) -> String): Map<String, String> =
+    groupBy(keyOf).mapNotNull { (key, tasks) ->
+        val labels = tasks.map { it.label.ifBlank { it.taskName } }.distinct()
+        // 一个 key 对应多个展示名时无法从回调里分辨具体实例，保留原始 key 比随机取后者可靠
+        if (labels.size == 1) key to labels.single() else null
+    }.toMap()
+
+fun RunPlan.taskLabelMap(): Map<String, String> = tasks.labelsBy { it.taskName }
+
+fun RunPlan.entryLabelMap(): Map<String, String> = tasks.labelsBy { it.entry }

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunPlanBuilder.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunPlanBuilder.kt
@@ -117,7 +117,8 @@ object RunPlanBuilder {
                 taskName = task.name,
                 entry = task.entry,
                 pipelineOverrides = patches,
-                label = task.label.ifBlank { task.name },
+                label = configured.customLabel?.trim()?.takeIf { it.isNotBlank() }
+                    ?: task.label.ifBlank { task.name },
             )
         }
 

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunSessionLog.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunSessionLog.kt
@@ -93,7 +93,16 @@ class RunSessionLogStore {
                 val stamp = Instant.ofEpochMilli(startedAt)
                     .atZone(ZoneId.systemDefault())
                     .format(FILE_STAMP)
-                val file = File(sessionDir(), "$PREFIX$stamp${SEPARATOR}${tasks.size}$SUFFIX")
+                val dir = sessionDir()
+                var file = File(dir, "$PREFIX$stamp${SEPARATOR}${tasks.size}$SUFFIX")
+                var collision = 0
+                while (file.exists()) {
+                    collision += 1
+                    file = File(
+                        dir,
+                        "$PREFIX$stamp${SEPARATOR}${tasks.size}${SEPARATOR}$collision$SUFFIX",
+                    )
+                }
                 val writer = RunSessionWriter(BufferedWriter(FileWriter(file, true)))
                 writer.write(listOf(RunSessionRecord.Header(startedAt, tasks)))
                 writer

--- a/app/src/main/java/com/aliothmoon/maafw/runner/RunnerContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/RunnerContracts.kt
@@ -8,15 +8,30 @@ import kotlinx.coroutines.flow.StateFlow
 /** 与 MaaFramework 的唯一执行边界；隐藏 JNI / handle / callback */
 interface RunnerPort {
     val state: StateFlow<RunnerState>
-    val events: Flow<RunnerEvent>
+    val events: Flow<RunnerEventEnvelope>
 
-    suspend fun start(plan: RunPlan): RunnerCommandResult
+    suspend fun start(plan: RunPlan, executionId: String): RunnerCommandResult
     suspend fun stop(): RunnerCommandResult
 }
+
+/**
+ * 事件产生那一刻的执行身份与任务现场。
+ *
+ * executionId 不能等消费时再查 state：onFinished 之后迟到回调仍应归属旧轮，
+ * 而下一轮 start 之后旧回调更不能借用新轮的任务名。
+ */
+data class RunnerEventEnvelope(
+    val executionId: String,
+    val currentTaskName: String? = null,
+    val currentTaskLabel: String? = null,
+    val event: RunnerEvent,
+)
 
 data class RunnerState(
     val phase: RunnerPhase = RunnerPhase.Idle,
     val activeExecution: ActiveExecution? = null,
+    /** Idle 后保留最近一轮身份；用于区分「本轮尾部」与「下一轮已开始后的旧回调」 */
+    val latestExecutionId: String? = null,
     /** 仅内存；进程重启可清空 */
     val latestResult: ExecutionResult? = null,
 )
@@ -37,16 +52,14 @@ data class ActiveExecution(
     val executionId: String,
     val runConfigurationId: RunConfigurationId,
     val currentTaskName: String?,
+    val currentTaskLabel: String? = null,
     /** 恒等于 [taskResults] 的条数：已结束的才算完成，正在跑的那条不算 */
     val completedTaskCount: Int,
     val totalTaskCount: Int,
     val taskResults: List<TaskResult>,
     /** 本轮冻住的 name → 展示名；缺的回落 [currentTaskName] */
     val taskLabels: Map<String, String> = emptyMap(),
-) {
-    val currentTaskLabel: String?
-        get() = currentTaskName?.let { taskLabels[it]?.takeIf(String::isNotBlank) ?: it }
-}
+)
 
 data class TaskResult(
     val taskName: String,
@@ -65,10 +78,18 @@ sealed interface ExecutionResult {
 
 /** 旁路观测（日志/进度）；不参与状态机判定 */
 sealed interface RunnerEvent {
+    /** 内部 drain marker：只标识事件流终局，不生成 UI 日志或屏保文本 */
+    data object ExecutionFinished : RunnerEvent
+
     /** 外壳自产的一句话，不是 MaaFramework 的原话 */
     data class Log(val message: String) : RunnerEvent
 
-    data class Progress(val taskName: String, val completed: Int, val total: Int) : RunnerEvent
+    data class Progress(
+        val taskName: String,
+        val completed: Int,
+        val total: Int,
+        val taskLabel: String? = null,
+    ) : RunnerEvent
 
     /**
      * MaaFramework 的一条原样通知

--- a/app/src/main/java/com/aliothmoon/maafw/runner/SessionLogHook.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/SessionLogHook.kt
@@ -19,7 +19,8 @@ class SessionLogHook(private val journal: RunJournal) : RunEnvHook {
     override val gating: Boolean = false
 
     override suspend fun engage(ctx: RunContext): EngageResult {
-        journal.begin(ctx.plan)
-        return EngageResult.Engaged { reason -> journal.end(reason) }
+        val executionId = ctx.executionId
+        journal.begin(ctx.plan, executionId)
+        return EngageResult.Engaged { reason -> journal.endAfterDrain(executionId, reason) }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maafw/runner/StubRunnerPort.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/StubRunnerPort.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
 sealed interface StubTaskOutcome {
@@ -39,11 +38,11 @@ class StubRunnerPort(
     private val _state = MutableStateFlow(RunnerState())
     override val state: StateFlow<RunnerState> = _state.asStateFlow()
 
-    private val _events = MutableSharedFlow<RunnerEvent>(
+    private val _events = MutableSharedFlow<RunnerEventEnvelope>(
         extraBufferCapacity = 64,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-    override val events: Flow<RunnerEvent> = _events.asSharedFlow()
+    override val events: Flow<RunnerEventEnvelope> = _events.asSharedFlow()
 
     private val commandMutex = Mutex()
 
@@ -54,22 +53,30 @@ class StubRunnerPort(
         val stopRequested = AtomicBoolean(false)
     }
 
-    override suspend fun start(plan: RunPlan): RunnerCommandResult = commandMutex.withLock {
+    override suspend fun start(plan: RunPlan, executionId: String): RunnerCommandResult = commandMutex.withLock {
         if (_state.value.phase != RunnerPhase.Idle) {
             return RunnerCommandResult.Rejected(uiTextFromFramework("Busy"))
         }
-        val context = ExecutionContext(UUID.randomUUID().toString())
+        val context = ExecutionContext(executionId)
         currentContext = context
         val execution = ActiveExecution(
             executionId = context.executionId,
             runConfigurationId = plan.runConfigurationId,
             currentTaskName = null,
+            currentTaskLabel = null,
             completedTaskCount = 0,
             totalTaskCount = plan.tasks.size,
             taskResults = emptyList(),
             taskLabels = plan.taskLabelMap(),
         )
-        _state.update { it.copy(phase = RunnerPhase.Preparing, activeExecution = execution) }
+        _state.update {
+            it.copy(
+                phase = RunnerPhase.Preparing,
+                activeExecution = execution,
+                latestExecutionId = context.executionId,
+                latestResult = null,
+            )
+        }
         scope.launch { execute(plan, context) }
         RunnerCommandResult.Accepted
     }
@@ -86,31 +93,43 @@ class StubRunnerPort(
     }
 
     private suspend fun execute(plan: RunPlan, context: ExecutionContext) {
-        _events.tryEmit(RunnerEvent.Log("准备运行环境（${plan.resource.name}）"))
+        emit(context.executionId, RunnerEvent.Log("准备运行环境（${plan.resource.name}）"))
         delay(scenario.prepareDelayMillis)
 
         scenario.preparationFailure?.let { reason ->
-            finish(ExecutionResult.Failed(uiTextFromFramework(reason)))
+            finish(context, ExecutionResult.Failed(uiTextFromFramework(reason)))
             return
         }
 
         val results = mutableListOf<TaskResult>()
         for ((index, task) in plan.tasks.withIndex()) {
             if (context.stopRequested.get()) break
+            val taskLabel = task.label.takeIf(String::isNotBlank) ?: task.taskName
             _state.update {
                 it.copy(
                     phase = RunnerPhase.Running,
                     activeExecution = it.activeExecution?.copy(
                         currentTaskName = task.taskName,
+                        currentTaskLabel = taskLabel,
                         completedTaskCount = index,
                         taskResults = results.toList(),
                     ),
                 )
             }
             if (scenario.emitProgress) {
-                _events.tryEmit(RunnerEvent.Progress(task.taskName, index, plan.tasks.size))
+                emit(
+                    context.executionId,
+                    RunnerEvent.Progress(task.taskName, index, plan.tasks.size, taskLabel),
+                    task.taskName,
+                    taskLabel,
+                )
             }
-            _events.tryEmit(RunnerEvent.Log("开始任务: ${task.taskName}"))
+            emit(
+                context.executionId,
+                RunnerEvent.Log("开始任务: ${task.taskName}"),
+                task.taskName,
+                taskLabel,
+            )
             delay(scenario.taskDelayMillis)
             if (context.stopRequested.get()) break
 
@@ -120,8 +139,11 @@ class StubRunnerPort(
                 is StubTaskOutcome.Failure -> TaskResult(task.taskName, success = false, message = outcome.message)
             }
             results += result
-            _events.tryEmit(
+            emit(
+                context.executionId,
                 RunnerEvent.Log(if (result.success) "任务完成: ${task.taskName}" else "任务失败: ${task.taskName}"),
+                task.taskName,
+                taskLabel,
             )
             _state.update {
                 it.copy(
@@ -138,12 +160,36 @@ class StubRunnerPort(
             results.any { !it.success } -> ExecutionResult.CompletedWithFailures(results.toList())
             else -> ExecutionResult.Completed(results.toList())
         }
-        finish(result)
+        finish(context, result)
     }
 
-    private fun finish(result: ExecutionResult) {
+    private fun finish(context: ExecutionContext, result: ExecutionResult) {
         currentContext = null
-        _events.tryEmit(RunnerEvent.Log("本轮执行结束: ${result::class.simpleName}"))
-        _state.update { RunnerState(phase = RunnerPhase.Idle, activeExecution = null, latestResult = result) }
+        emit(context.executionId, RunnerEvent.Log("本轮执行结束: ${result::class.simpleName}"))
+        emit(context.executionId, RunnerEvent.ExecutionFinished)
+        _state.update {
+            RunnerState(
+                phase = RunnerPhase.Idle,
+                activeExecution = null,
+                latestExecutionId = context.executionId,
+                latestResult = result,
+            )
+        }
+    }
+
+    private fun emit(
+        executionId: String,
+        event: RunnerEvent,
+        currentTaskName: String? = null,
+        currentTaskLabel: String? = null,
+    ) {
+        _events.tryEmit(
+            RunnerEventEnvelope(
+                executionId = executionId,
+                currentTaskName = currentTaskName,
+                currentTaskLabel = currentTaskLabel,
+                event = event,
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/aliothmoon/maafw/runner/WatchdogNoticeHook.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/WatchdogNoticeHook.kt
@@ -40,13 +40,14 @@ class WatchdogNoticeHook(
     override val gating: Boolean = false
 
     override suspend fun engage(ctx: RunContext): EngageResult {
+        val executionId = ctx.executionId
         val job = scope.launch {
             watchdogState
                 // 上一轮留下的坏状态还没被 2s 轮询刷掉，别拿它当本轮的事
                 .dropWhile { it.isLost }
                 .distinctUntilChanged()
                 .filter { it.isLost }
-                .collect { state -> journal.note(RunNote.Warning, describe(state)) }
+                .collect { state -> journal.note(executionId, RunNote.Warning, describe(state)) }
         }
         return EngageResult.Engaged { job.cancel() }
     }

--- a/app/src/main/java/com/aliothmoon/maafw/service/RunForegroundService.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/service/RunForegroundService.kt
@@ -140,7 +140,8 @@ class RunForegroundService : Service() {
      * `{name}` 这些形态得先补完，否则推给用户的是没处理过的模板
      */
     private suspend fun observeFocusNotifications() {
-        focusDispatcher.resolved.collect { focus ->
+        focusDispatcher.resolved.collect { dispatch ->
+            val focus = dispatch.focus
             if (FocusChannel.Notification !in focus.channels) return@collect
             ensureFocusChannel()
             val notification = NotificationCompat.Builder(this, FOCUS_CHANNEL_ID)

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -206,7 +206,7 @@ class SessionViewModel(
             for (intent in intents) handle(intent)
         }
         viewModelScope.launch {
-            focusDispatcher.resolved.collect { focus -> dispatchFocus(focus) }
+            focusDispatcher.resolved.collect { dispatch -> dispatchFocus(dispatch.focus) }
         }
         viewModelScope.launch {
             combine(projectRepository.state, configurationStore.data) { p, c -> p to c }

--- a/app/src/main/java/com/aliothmoon/maafw/telemetry/TelemetryController.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/telemetry/TelemetryController.kt
@@ -9,7 +9,7 @@ import com.aliothmoon.maafw.runner.ExecutionResult
 import com.aliothmoon.maafw.runner.FocusDispatcher
 import com.aliothmoon.maafw.runner.RunnerPhase
 import com.aliothmoon.maafw.runner.RunnerPort
-import com.aliothmoon.maafw.settings.AppSettingsManager
+import com.aliothmoon.maafw.settings.AppSettingsGateway
 import io.sentry.ITransaction
 import io.sentry.Sentry
 import io.sentry.SentryLevel
@@ -31,14 +31,18 @@ import timber.log.Timber
 class TelemetryController(
     private val context: Context,
     private val projectRepository: ProjectRepository,
-    private val settings: AppSettingsManager,
+    private val settings: AppSettingsGateway,
     private val focusDispatcher: FocusDispatcher,
     private val runnerPort: RunnerPort,
     private val scope: CoroutineScope,
 ) {
 
     private var active: TelemetryDefinition? = null
-    private var runTransaction: ITransaction? = null
+
+    private data class ActiveRun(val transaction: ITransaction?)
+
+    @Volatile
+    private var activeRun = ActiveRun(transaction = null)
 
     fun setup() {
         scope.launch {
@@ -53,7 +57,8 @@ class TelemetryController(
             }.distinctUntilChanged().collect(::apply)
         }
         scope.launch {
-            focusDispatcher.traced.collect { focus ->
+            focusDispatcher.traced.collect { dispatch ->
+                val focus = dispatch.focus
                 if (active == null) return@collect
                 Sentry.captureMessage(focus.message, SentryLevel.INFO)
             }
@@ -61,9 +66,13 @@ class TelemetryController(
         scope.launch {
             runnerPort.state.collect { state ->
                 val definition = active ?: return@collect
-                if (!definition.tracing) return@collect
                 when (state.phase) {
-                    RunnerPhase.Preparing -> startRunTransaction(state.activeExecution?.totalTaskCount)
+                    RunnerPhase.Preparing -> {
+                        activeRun = ActiveRun(transaction = null)
+                        if (definition.tracing) {
+                            startRunTransaction(state.activeExecution?.totalTaskCount)
+                        }
+                    }
                     RunnerPhase.Idle -> finishRunTransaction(state.latestResult)
                     else -> Unit
                 }
@@ -106,15 +115,17 @@ class TelemetryController(
     }
 
     private fun startRunTransaction(taskCount: Int?) {
-        if (runTransaction != null) return
-        runTransaction = Sentry.startTransaction("run", "task.run").apply {
+        if (activeRun.transaction != null) return
+        val transaction = Sentry.startTransaction("run", "task.run").apply {
             taskCount?.let { setData("task_count", it) }
         }
+        activeRun = activeRun.copy(transaction = transaction)
     }
 
     private fun finishRunTransaction(result: ExecutionResult?) {
-        val transaction = runTransaction ?: return
-        runTransaction = null
+        val run = activeRun
+        activeRun = ActiveRun(transaction = null)
+        val transaction = run.transaction ?: return
         transaction.finish(
             when (result) {
                 is ExecutionResult.Completed -> SpanStatus.OK

--- a/app/src/test/java/com/aliothmoon/maafw/notification/RunProgressSnapshotTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/notification/RunProgressSnapshotTest.kt
@@ -77,6 +77,21 @@ class RunProgressSnapshotTest {
     }
 
     @Test
+    fun `duplicate task names use the captured instance label`() {
+        val snapshot = RunProgressSnapshots.from(
+            phase = RunnerPhase.Running,
+            execution = execution(
+                done = 1,
+                total = 2,
+                currentTaskName = "Fight",
+                currentTaskLabel = "第二次",
+            ),
+            statusText = null,
+        )
+        assertEquals("1/2 · 第二次", snapshot.contentText)
+    }
+
+    @Test
     fun `stopping keeps a determinate bar`() {
         val snapshot = RunProgressSnapshots.from(
             phase = RunnerPhase.Stopping,
@@ -114,11 +129,13 @@ class RunProgressSnapshotTest {
         done: Int,
         total: Int,
         currentTaskName: String? = null,
+        currentTaskLabel: String? = null,
         taskLabels: Map<String, String> = emptyMap(),
     ) = ActiveExecution(
         executionId = "e1",
         runConfigurationId = RunConfigurationId("c1"),
         currentTaskName = currentTaskName,
+        currentTaskLabel = currentTaskLabel,
         completedTaskCount = done,
         totalTaskCount = total,
         taskResults = emptyList(),

--- a/app/src/test/java/com/aliothmoon/maafw/remote/MaaRunnerCallbackDispatcherTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/remote/MaaRunnerCallbackDispatcherTest.kt
@@ -1,0 +1,69 @@
+package com.aliothmoon.maafw.remote
+
+import com.aliothmoon.maafw.IMaaRunnerCallback
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+class MaaRunnerCallbackDispatcherTest {
+
+    @Test
+    fun `terminal callback waits for an earlier raw callback`() {
+        val calls = mutableListOf<String>()
+        val rawStarted = CountDownLatch(1)
+        val releaseRaw = CountDownLatch(1)
+        val callback = mockk<IMaaRunnerCallback>()
+        every { callback.onEvent(any(), any()) } answers {
+            calls += "raw"
+            rawStarted.countDown()
+            releaseRaw.await(5, TimeUnit.SECONDS)
+        }
+        every { callback.onFinished(any(), any()) } answers {
+            calls += "finished"
+        }
+
+        val executor = ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            LinkedBlockingQueue(),
+        )
+        val dispatcher = MaaRunnerCallbackDispatcher(executor)
+        dispatcher.setCallback(callback)
+        try {
+            val rawThread = thread {
+                dispatcher.dispatch {
+                    onEvent("Tasker.Task.Failed", """{"entry":"Fight"}""")
+                }
+            }
+            assertTrue(rawStarted.await(5, TimeUnit.SECONDS))
+
+            val terminalThread = thread {
+                dispatcher.dispatchAndAwait {
+                    onFinished(2, null)
+                }
+            }
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (executor.queue.isEmpty() && System.nanoTime() < deadline) {
+                Thread.sleep(10)
+            }
+            assertTrue("terminal callback was not queued", executor.queue.isNotEmpty())
+
+            releaseRaw.countDown()
+            rawThread.join(TimeUnit.SECONDS.toMillis(5))
+            terminalThread.join(TimeUnit.SECONDS.toMillis(5))
+
+            assertEquals(listOf("raw", "finished"), calls)
+        } finally {
+            dispatcher.close()
+        }
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/runner/EnvironmentHooksTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/EnvironmentHooksTest.kt
@@ -36,13 +36,24 @@ class EnvironmentHooksTest {
     )
 
     private fun context(runMode: RunMode = RunMode.BACKGROUND) =
-        RunContext(RunTrigger.Manual, runMode, plan, journal = DiscardingRunJournal)
+        RunContext(
+            executionId = "execution-1",
+            trigger = RunTrigger.Manual,
+            runMode = runMode,
+            plan = plan,
+            journal = DiscardingRunJournal,
+        )
 
     private class RecordingScreenSaver(private val showSucceeds: Boolean = true) : RunScreenSaver {
         var shown = 0
         var hidden = 0
-        override suspend fun show(): Boolean {
-            if (showSucceeds) shown++
+        val shownExecutionIds = mutableListOf<String?>()
+
+        override suspend fun show(executionId: String?): Boolean {
+            if (showSucceeds) {
+                shown++
+                shownExecutionIds += executionId
+            }
             return showSucceeds
         }
 
@@ -150,6 +161,7 @@ class EnvironmentHooksTest {
         release!!(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
 
         assertEquals(1, saver.shown)
+        assertEquals(listOf("execution-1"), saver.shownExecutionIds)
         assertEquals(1, saver.hidden)
     }
 

--- a/app/src/test/java/com/aliothmoon/maafw/runner/FocusDispatcherTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/FocusDispatcherTest.kt
@@ -3,10 +3,12 @@ package com.aliothmoon.maafw.runner
 import com.aliothmoon.maafw.domain.ControllerDefinition
 import com.aliothmoon.maafw.domain.ProjectDefinition
 import com.aliothmoon.maafw.domain.ResourceDefinition
+import com.aliothmoon.maafw.domain.RunConfigurationId
 import com.aliothmoon.maafw.domain.TaskGroupDefinition
 import com.aliothmoon.maafw.project.FakeProjectRepository
 import com.aliothmoon.maafw.project.ProjectState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -62,21 +64,25 @@ class FocusDispatcherTest {
         dispatcher: FocusDispatcher,
         event: RunnerEvent.Focus,
     ): FocusMessage {
-        val received = mutableListOf<FocusMessage>()
+        val received = mutableListOf<FocusDispatcher.Dispatch>()
         backgroundScope.launch { dispatcher.resolved.collect { received += it } }
         advanceUntilIdle()
         runner.emit(event)
         advanceUntilIdle()
-        return received.single()
+        return received.single().focus
     }
 
-    private fun focus(content: String, placeholders: Map<String, String> = emptyMap()) =
+    private fun focus(
+        content: String,
+        placeholders: Map<String, String> = emptyMap(),
+        trace: Boolean = false,
+    ) =
         RunnerEvent.Focus(
             FocusMessage(
                 message = "Node.PipelineNode.Succeeded",
                 content = content,
                 channels = setOf(FocusChannel.Log),
-                trace = false,
+                trace = trace,
                 placeholders = placeholders,
             ),
         )
@@ -87,6 +93,122 @@ class FocusDispatcherTest {
         val result = completed(runner, dispatcherWith(runner), focus("显影罐不足"))
         assertEquals("显影罐不足", result.content)
     }
+
+    @Test
+    fun `late focus keeps its execution id`() = runTest(UnconfinedTestDispatcher()) {
+        val runner = RecordingEventRunnerPort()
+        val dispatcher = dispatcherWith(runner)
+        val received = mutableListOf<FocusDispatcher.Dispatch>()
+        backgroundScope.launch { dispatcher.resolved.collect { received += it } }
+        advanceUntilIdle()
+
+        runner.emit(focus("迟到的通知"), executionId = "old-execution")
+        advanceUntilIdle()
+
+        assertEquals("old-execution", received.single().executionId)
+    }
+
+    @Test
+    fun `focus completing after the next run starts is dropped`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = RecordingEventRunnerPort()
+            val resolver = BlockingFocusContentResolver()
+            val dispatcher = dispatcherWith(runner, resolver)
+            val received = mutableListOf<FocusDispatcher.Dispatch>()
+            backgroundScope.launch { dispatcher.resolved.collect { received += it } }
+            advanceUntilIdle()
+
+            runner.prepare(plan(), "execution-1")
+            runner.emit(focus("./docs/old.md"), executionId = "execution-1")
+            resolver.entered.await()
+            runner.prepare(plan(), "execution-2")
+            resolver.release.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FocusDispatcher.Dispatch>(), received)
+        }
+
+    @Test
+    fun `traced focus completing after the next run starts is dropped`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = RecordingEventRunnerPort()
+            val resolver = BlockingFocusContentResolver()
+            val dispatcher = dispatcherWith(runner, resolver)
+            val traced = mutableListOf<FocusDispatcher.Dispatch>()
+            backgroundScope.launch { dispatcher.traced.collect { traced += it } }
+            advanceUntilIdle()
+
+            runner.prepare(plan(), "execution-1")
+            runner.emit(focus("./docs/old.md", trace = true), executionId = "execution-1")
+            resolver.entered.await()
+            runner.prepare(plan(), "execution-2")
+            resolver.release.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FocusDispatcher.Dispatch>(), traced)
+        }
+
+    @Test
+    fun `terminal drain survives being superseded by the next run`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = RecordingEventRunnerPort()
+            val resolver = BlockingFocusContentResolver()
+            val dispatcher = dispatcherWith(runner, resolver)
+            val recording = mutableListOf<FocusDispatcher.RecordingEvent>()
+            backgroundScope.launch { dispatcher.recording.collect { recording += it } }
+            advanceUntilIdle()
+
+            runner.prepare(plan(), "execution-1")
+            runner.emit(focus("./docs/old.md"), executionId = "execution-1")
+            resolver.entered.await()
+            runner.prepare(plan(), "execution-2")
+            resolver.release.complete(Unit)
+            runner.settle("execution-1")
+            runner.emit(
+                RunnerEvent.ExecutionFinished,
+                executionId = "execution-1",
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(FocusDispatcher.RecordingEvent.Drained("execution-1")),
+                recording,
+            )
+        }
+
+    @Test
+    fun `focus from the latest finished execution still has a drain tail`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = RecordingEventRunnerPort()
+            val dispatcher = dispatcherWith(runner)
+            val received = mutableListOf<FocusDispatcher.Dispatch>()
+            backgroundScope.launch { dispatcher.resolved.collect { received += it } }
+            advanceUntilIdle()
+
+            runner.settle("execution-1")
+            runner.emit(focus("迟到的通知"), executionId = "execution-1")
+            advanceUntilIdle()
+
+            assertEquals("execution-1", received.single().executionId)
+        }
+
+    @Test
+    fun `focus from an older finished execution stays dropped`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = RecordingEventRunnerPort()
+            val dispatcher = dispatcherWith(runner)
+            val received = mutableListOf<FocusDispatcher.Dispatch>()
+            backgroundScope.launch { dispatcher.resolved.collect { received += it } }
+            advanceUntilIdle()
+
+            runner.settle("execution-1")
+            runner.prepare(plan(), "execution-2")
+            runner.settle("execution-2")
+            runner.emit(focus("过期的通知"), executionId = "execution-1")
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FocusDispatcher.Dispatch>(), received)
+        }
 
     @Test
     fun `translation key is resolved`() = runTest(UnconfinedTestDispatcher()) {
@@ -161,5 +283,25 @@ class FocusDispatcherTest {
             ),
         )
         assertEquals(channels, completed(runner, dispatcherWith(runner), event).channels)
+    }
+
+    private fun plan() = RunPlan(
+        projectName = "demo",
+        projectVersion = "1",
+        controller = ControllerDefinition(),
+        resource = ResourceDefinition(name = "official", paths = listOf("resource")),
+        runConfigurationId = RunConfigurationId("cfg"),
+        tasks = emptyList(),
+    )
+
+    private class BlockingFocusContentResolver : FocusContentResolver {
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        override suspend fun resolve(content: String): String {
+            entered.complete(Unit)
+            release.await()
+            return "resolved: $content"
+        }
     }
 }

--- a/app/src/test/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPortTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPortTest.kt
@@ -8,6 +8,7 @@ import com.aliothmoon.maafw.domain.RunConfigurationId
 import com.aliothmoon.maafw.domain.RunMode
 import com.aliothmoon.maafw.privileged.FakePrivilegedService
 import com.aliothmoon.maafw.privileged.FakePrivilegedServicePort
+import com.aliothmoon.maafw.privileged.PrivilegedServiceState
 import com.aliothmoon.maafw.project.PiInstaller
 import io.mockk.every
 import io.mockk.mockk
@@ -16,12 +17,15 @@ import io.mockk.unmockkObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -63,6 +67,17 @@ class MaaFrameworkRunnerPortTest {
         tasks = listOf(RuntimeTask("启动游戏", "Start", emptyList())),
     )
 
+    private fun labeledPlan(label: String) = plan().copy(
+        tasks = listOf(RuntimeTask("启动游戏", "Start", emptyList(), label = label)),
+    )
+
+    private fun duplicateTaskPlan() = plan().copy(
+        tasks = listOf(
+            RuntimeTask("启动游戏", "Start", emptyList(), label = "第一次"),
+            RuntimeTask("启动游戏", "Start", emptyList(), label = "第二次"),
+        ),
+    )
+
     private fun port(
         scope: TestScope,
         service: FakePrivilegedService = FakePrivilegedService(),
@@ -81,7 +96,7 @@ class MaaFrameworkRunnerPortTest {
             servicePort = servicePort,
         )
         // JVM 单测构造不了 AIDL Stub；本文件只测 phase，不测回调转发
-        runner.bindRunnerCallback = {}
+        runner.bindRunnerCallback = { _, _ -> }
         return runner to servicePort
     }
 
@@ -92,7 +107,7 @@ class MaaFrameworkRunnerPortTest {
         val servicePort = FakePrivilegedServicePort(service).apply { holdUseService = hold }
         val (runner, _) = port(this, service, servicePort)
 
-        val started = async { runner.start(plan()) }
+        val started = async { runner.start(plan(), "execution-1") }
         advanceUntilIdle()
         assertEquals(RunnerPhase.Preparing, runner.state.value.phase)
 
@@ -108,13 +123,143 @@ class MaaFrameworkRunnerPortTest {
     }
 
     @Test
+    fun `a stale callback keeps its execution context and cannot mutate the next run`() = runTest(dispatcher) {
+        val (runner, _) = port(this)
+        val callbacks = mutableListOf<MaaFrameworkRunnerPort.ExecutionCallback>()
+        val events = mutableListOf<RunnerEventEnvelope>()
+        runner.bindRunnerCallback = { _, callback -> callbacks += callback }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            runner.events.collect { events += it }
+        }
+        advanceUntilIdle()
+
+        runner.start(labeledPlan("旧任务"), "execution-1")
+        val oldCallback = callbacks.single()
+        oldCallback.onTaskStarted("回调别名", 0, 1)
+        oldCallback.onFinished(RunOutcome.COMPLETED, null)
+        advanceUntilIdle()
+
+        runner.start(labeledPlan("新任务"), "execution-2")
+        oldCallback.onTaskStarted("回调别名", 0, 1)
+        oldCallback.onTaskFinished("启动游戏", false, "late")
+        oldCallback.onFinished(RunOutcome.COMPLETED, null)
+        advanceUntilIdle()
+
+        val active = runner.state.value.activeExecution
+        assertEquals("execution-2", active?.executionId)
+        assertNull(active?.currentTaskName)
+        assertEquals(emptyList<TaskResult>(), active?.taskResults)
+        assertEquals(RunnerPhase.Running, runner.state.value.phase)
+
+        val progress = events.filterIsInstance<RunnerEventEnvelope>()
+            .mapNotNull { it.event as? RunnerEvent.Progress }
+        assertEquals(listOf("旧任务", "旧任务"), progress.map { it.taskLabel })
+        assertEquals(listOf("execution-1", "execution-1", "execution-1"), events.map { it.executionId })
+    }
+
+    @Test
+    fun `the terminal marker is emitted before state becomes idle`() = runTest(dispatcher) {
+        val (runner, _) = port(this)
+        val callbacks = mutableListOf<MaaFrameworkRunnerPort.ExecutionCallback>()
+        val events = mutableListOf<RunnerEventEnvelope>()
+        var phaseAtTerminal: RunnerPhase? = null
+        runner.bindRunnerCallback = { _, callback -> callbacks += callback }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            runner.events.collect { envelope ->
+                if (envelope.event is RunnerEvent.ExecutionFinished) {
+                    phaseAtTerminal = runner.state.value.phase
+                }
+                events += envelope
+            }
+        }
+        advanceUntilIdle()
+
+        runner.start(labeledPlan("旧任务"), "execution-1")
+        callbacks.single().onFinished(RunOutcome.COMPLETED_WITH_FAILURES, null)
+
+        assertEquals(RunnerPhase.Running, phaseAtTerminal)
+        assertEquals(RunnerPhase.Idle, runner.state.value.phase)
+        assertEquals("execution-1", events.single().executionId)
+        assertTrue(events.single().event is RunnerEvent.ExecutionFinished)
+    }
+
+    @Test
+    fun `forced abort emits the terminal marker for its execution`() = runTest(dispatcher) {
+        val servicePort = FakePrivilegedServicePort()
+        val (runner, _) = port(this, servicePort = servicePort)
+        val events = mutableListOf<RunnerEventEnvelope>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            runner.events.collect { events += it }
+        }
+        advanceUntilIdle()
+
+        runner.start(labeledPlan("当前任务"), "execution-1")
+        servicePort.emit(PrivilegedServiceState.Died)
+        repeat(4) { testScheduler.runCurrent() }
+
+        assertEquals(RunnerPhase.Idle, runner.state.value.phase)
+        assertEquals("execution-1", runner.state.value.latestExecutionId)
+        assertEquals(
+            listOf("execution-1"),
+            events
+                .filter { it.event is RunnerEvent.ExecutionFinished }
+                .map { it.executionId },
+        )
+    }
+
+    @Test
+    fun `duplicate task names keep the label of the started instance`() = runTest(dispatcher) {
+        val (runner, _) = port(this)
+        val callbacks = mutableListOf<MaaFrameworkRunnerPort.ExecutionCallback>()
+        val events = mutableListOf<RunnerEventEnvelope>()
+        runner.bindRunnerCallback = { _, callback -> callbacks += callback }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            runner.events.collect { events += it }
+        }
+        advanceUntilIdle()
+
+        runner.start(duplicateTaskPlan(), "execution-1")
+        val callback = callbacks.single()
+        callback.onTaskStarted("回调别名", 0, 2)
+        assertEquals("第一次", runner.state.value.activeExecution?.currentTaskLabel)
+
+        callback.onTaskStarted("回调别名", 1, 2)
+        assertEquals("第二次", runner.state.value.activeExecution?.currentTaskLabel)
+
+        val progress = events.mapNotNull { it.event as? RunnerEvent.Progress }
+        assertEquals(listOf("第一次", "第二次"), progress.map { it.taskLabel })
+        assertEquals(
+            listOf("第一次", "第二次"),
+            events.mapNotNull { it.currentTaskLabel },
+        )
+    }
+
+    @Test
+    fun `blank task labels fall back to the task name in progress`() = runTest(dispatcher) {
+        val (runner, _) = port(this)
+        val callbacks = mutableListOf<MaaFrameworkRunnerPort.ExecutionCallback>()
+        val events = mutableListOf<RunnerEventEnvelope>()
+        runner.bindRunnerCallback = { _, callback -> callbacks += callback }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            runner.events.collect { events += it }
+        }
+        advanceUntilIdle()
+
+        runner.start(labeledPlan(""), "execution-1")
+        callbacks.single().onTaskStarted("回调别名", 0, 1)
+
+        val progress = events.mapNotNull { it.event as? RunnerEvent.Progress }
+        assertEquals(listOf("启动游戏"), progress.map { it.taskLabel })
+    }
+
+    @Test
     fun `start rejection during Stopping returns to Idle`() = runTest(dispatcher) {
         val service = FakePrivilegedService()
         val hold = CompletableDeferred<Unit>()
         val servicePort = FakePrivilegedServicePort(service).apply { holdUseService = hold }
         val (runner, _) = port(this, service, servicePort)
 
-        val started = async { runner.start(plan()) }
+        val started = async { runner.start(plan(), "execution-1") }
         advanceUntilIdle()
         assertEquals(RunnerPhase.Preparing, runner.state.value.phase)
 
@@ -134,7 +279,7 @@ class MaaFrameworkRunnerPortTest {
         val servicePort = FakePrivilegedServicePort().apply { holdUseService = hold }
         val (runner, _) = port(this, servicePort = servicePort)
 
-        val started = async { runner.start(plan()) }
+        val started = async { runner.start(plan(), "execution-1") }
         advanceUntilIdle()
         assertEquals(RunnerPhase.Preparing, runner.state.value.phase)
 

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RecordingEventRunnerPort.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RecordingEventRunnerPort.kt
@@ -11,21 +11,82 @@ import kotlinx.coroutines.flow.asStateFlow
 /** 只为按需推事件；不模拟执行，start/stop 一律受理 */
 class RecordingEventRunnerPort : RunnerPort {
 
+    val startedExecutionIds = mutableListOf<String>()
+
     private val _state = MutableStateFlow(RunnerState())
     override val state: StateFlow<RunnerState> = _state.asStateFlow()
 
+    fun prepare(plan: RunPlan, executionId: String) {
+        _state.value = RunnerState(
+            phase = RunnerPhase.Preparing,
+            latestExecutionId = executionId,
+            activeExecution = ActiveExecution(
+                executionId = executionId,
+                runConfigurationId = plan.runConfigurationId,
+                currentTaskName = null,
+                completedTaskCount = 0,
+                totalTaskCount = plan.tasks.size,
+                taskResults = emptyList(),
+                taskLabels = plan.taskLabelMap(),
+            ),
+        )
+    }
+
     // replay=0 但缓冲足够大：VM 的 collect 在 init 里就挂上了，emit 不会丢
-    private val _events = MutableSharedFlow<RunnerEvent>(
+    private val _events = MutableSharedFlow<RunnerEventEnvelope>(
         extraBufferCapacity = 1024,
         onBufferOverflow = BufferOverflow.SUSPEND,
     )
-    override val events: Flow<RunnerEvent> = _events.asSharedFlow()
+    override val events: Flow<RunnerEventEnvelope> = _events.asSharedFlow()
 
-    fun emit(event: RunnerEvent) {
-        check(_events.tryEmit(event)) { "事件缓冲满了，调大 extraBufferCapacity" }
+    fun emit(
+        event: RunnerEvent,
+        executionId: String = DEFAULT_EXECUTION_ID,
+        currentTaskName: String? = null,
+        currentTaskLabel: String? = null,
+    ) {
+        _events.tryEmit(
+            RunnerEventEnvelope(
+                executionId = executionId,
+                currentTaskName = currentTaskName,
+                currentTaskLabel = currentTaskLabel,
+                event = event,
+            ),
+        )
     }
 
-    override suspend fun start(plan: RunPlan): RunnerCommandResult = RunnerCommandResult.Accepted
+    override suspend fun start(plan: RunPlan, executionId: String): RunnerCommandResult {
+        startedExecutionIds += executionId
+        _state.value = RunnerState(
+            phase = RunnerPhase.Running,
+            latestExecutionId = executionId,
+            activeExecution = ActiveExecution(
+                executionId = executionId,
+                runConfigurationId = plan.runConfigurationId,
+                currentTaskName = null,
+                completedTaskCount = 0,
+                totalTaskCount = plan.tasks.size,
+                taskResults = emptyList(),
+                taskLabels = plan.taskLabelMap(),
+            ),
+        )
+        return RunnerCommandResult.Accepted
+    }
 
-    override suspend fun stop(): RunnerCommandResult = RunnerCommandResult.Accepted
+    override suspend fun stop(): RunnerCommandResult {
+        settle(_state.value.latestExecutionId ?: _state.value.activeExecution?.executionId)
+        return RunnerCommandResult.Accepted
+    }
+
+    fun settle(executionId: String?) {
+        _state.value = RunnerState(
+            phase = RunnerPhase.Idle,
+            latestExecutionId = executionId ?: _state.value.latestExecutionId,
+            latestResult = ExecutionResult.Completed(emptyList()),
+        )
+    }
+
+    companion object {
+        const val DEFAULT_EXECUTION_ID = "test-execution"
+    }
 }

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunLauncherTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunLauncherTest.kt
@@ -13,6 +13,7 @@ import com.aliothmoon.maafw.domain.TaskDefinition
 import com.aliothmoon.maafw.domain.TaskGroupDefinition
 import com.aliothmoon.maafw.domain.UserConfiguration
 import com.aliothmoon.maafw.i18n.isResource
+import com.aliothmoon.maafw.i18n.UiText
 import com.aliothmoon.maafw.i18n.uiTextOf
 import com.aliothmoon.maafw.project.FakeProjectRepository
 import com.aliothmoon.maafw.project.ProjectState
@@ -79,6 +80,7 @@ class RunLauncherTest {
         project: ProjectState = ProjectState.Ready(definition, emptyList()),
         configurationStore: InMemoryUserConfigurationStore = store(),
         runMode: RunMode = RunMode.BACKGROUND,
+        journal: RunJournal = DiscardingRunJournal,
     ) = RunLauncher(
         projectRepository = FakeProjectRepository(project),
         configurationStore = configurationStore,
@@ -87,7 +89,7 @@ class RunLauncherTest {
         hooks = hooks,
         runMode = { runMode },
         scope = scope,
-        journal = DiscardingRunJournal,
+        journal = journal,
     )
 
     private fun fastStub(scope: CoroutineScope) = StubRunnerPort(
@@ -119,6 +121,24 @@ class RunLauncherTest {
 
         assertEquals(RunLaunchResult.Started, launcher.launch(RunTrigger.Manual))
         assertEquals(1, keepAlive.startCount)
+    }
+
+    @Test
+    fun `journal and runner receive the same generated execution id`() = runTest(testDispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val journal = RecordingRunJournal()
+        val launcher = launcher(
+            scope = backgroundScope,
+            runner = runner,
+            hooks = listOf(SessionLogHook(journal)),
+            journal = journal,
+        )
+
+        assertEquals(RunLaunchResult.Started, launcher.launch(RunTrigger.Manual))
+
+        val executionId = journal.begins.singleOrNull()?.second
+        assertTrue(executionId != null && executionId.isNotBlank())
+        assertEquals(listOf(executionId), runner.startedExecutionIds)
     }
 
     /** 保活是执行的一部分：没受理就拉，前台服务会因为读到非 busy 而当场自停 */
@@ -565,5 +585,17 @@ class RunLauncherTest {
                 log += "release:$id"
             })
         }
+    }
+
+    private class RecordingRunJournal : RunJournal {
+        val begins = mutableListOf<Pair<RunPlan, String>>()
+
+        override suspend fun begin(plan: RunPlan, executionId: String) {
+            begins += plan to executionId
+        }
+
+        override suspend fun end(executionId: String, reason: RunEndReason) = Unit
+
+        override fun note(executionId: String, level: RunNote, text: UiText) = Unit
     }
 }

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunLogComposerTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunLogComposerTest.kt
@@ -10,7 +10,12 @@ import org.junit.Test
 class RunLogComposerTest {
 
     private val composer = RunLogComposer()
-    private val context = RunLogContext(currentTaskName = "启动应用", resourceLabel = "官服")
+    private val context = RunLogContext(
+        currentTaskName = "启动应用",
+        taskLabels = mapOf("Start" to "启动应用"),
+        entryLabels = mapOf("Start" to "启动应用"),
+        resourceLabel = "官服",
+    )
 
     private var nextId = 0L
     private var clock = 0L
@@ -44,6 +49,45 @@ class RunLogComposerTest {
             RunLogContext(),
         )
         assertEquals(UiText.Resource(R.string.run_log_task_starting, listOf("Start")), entry?.text)
+    }
+
+    @Test
+    fun `progress prefers the materialized task label`() {
+        val entry = compose(RunnerEvent.Progress("internal_start", 1, 3, "每日启动"))
+
+        assertEquals(UiText.Verbatim("每日启动 1/3"), entry?.text)
+    }
+
+    @Test
+    fun `task callbacks keep their own task when progress already advanced`() {
+        val entry = RunLogComposer().compose(
+            RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"rich_room"}"""),
+            1,
+            0,
+            RunLogContext(
+                currentTaskName = "ninja_book",
+                taskLabels = mapOf("rich_room" to "丰饶之间", "ninja_book" to "忍法帖"),
+                entryLabels = mapOf("rich_room" to "丰饶之间"),
+            ),
+        )
+
+        assertEquals(UiText.Resource(R.string.run_log_task_failed, listOf("丰饶之间")), entry?.text)
+    }
+
+    @Test
+    fun `entry labels do not collide with task-name labels`() {
+        val entry = RunLogComposer().compose(
+            RunnerEvent.Callback("Tasker.Task.Succeeded", """{"entry":"Fight"}"""),
+            1,
+            0,
+            RunLogContext(
+                currentTaskName = "Fight",
+                taskLabels = mapOf("Fight" to "错误任务"),
+                entryLabels = mapOf("Fight" to "战斗"),
+            ),
+        )
+
+        assertEquals(UiText.Resource(R.string.run_log_task_succeeded, listOf("战斗")), entry?.text)
     }
 
     @Test

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunLogRecorderTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunLogRecorderTest.kt
@@ -1,8 +1,10 @@
 package com.aliothmoon.maafw.runner
 
+import com.aliothmoon.maafw.R
 import com.aliothmoon.maafw.domain.ControllerDefinition
 import com.aliothmoon.maafw.domain.ResourceDefinition
 import com.aliothmoon.maafw.domain.RunConfigurationId
+import com.aliothmoon.maafw.i18n.UiText
 import com.aliothmoon.maafw.project.FakeProjectRepository
 import com.aliothmoon.maafw.project.ProjectState
 import com.aliothmoon.maafw.domain.ProjectDefinition
@@ -11,10 +13,14 @@ import com.aliothmoon.maafw.constant.AppPaths
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -76,11 +82,20 @@ class RunLogRecorderTest {
     private fun TestScope.settleRunLog() = testScheduler.advanceTimeBy(SETTLE_MILLIS)
 
     private fun sessionRecords(): List<RunSessionRecord> {
-        val file = File(logDir, "run").listFiles()?.single() ?: return emptyList()
+        val file = File(logDir, "run").listFiles()?.maxByOrNull { it.lastModified() } ?: return emptyList()
         return file.readLines()
             .filter { it.isNotBlank() }
             .map { LENIENT.decodeFromString(RunSessionRecord.serializer(), it) }
     }
+
+    private fun sessionRecordsFor(taskName: String): List<RunSessionRecord> =
+        File(logDir, "run").listFiles().orEmpty()
+            .map { file ->
+                file.readLines()
+                    .filter { it.isNotBlank() }
+                    .map { LENIENT.decodeFromString(RunSessionRecord.serializer(), it) }
+            }
+            .single { records -> (records.first() as? RunSessionRecord.Header)?.tasks == listOf(taskName) }
 
     @Test
     fun `user-facing lines update lastUserFacing immediately`() = runTest(dispatcher) {
@@ -166,6 +181,22 @@ class RunLogRecorderTest {
     }
 
     @Test
+    fun `clearing the log resets composer dedupe through recorder input`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        runner.emit(RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"清体力"}"""))
+        settleRunLog()
+        assertEquals(1, recorder.runLog.value.size)
+        recorder.clear()
+        testScheduler.runCurrent()
+        runner.emit(RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"清体力"}"""))
+        settleRunLog()
+
+        assertEquals("clear 后同一条被去重丢了", 1, recorder.runLog.value.size)
+    }
+
+    @Test
     fun `verbose callbacks do not become lastUserFacing`() = runTest(dispatcher) {
         val runner = RecordingEventRunnerPort()
         val recorder = recorder(runner)
@@ -181,10 +212,13 @@ class RunLogRecorderTest {
         val recorder = recorder(runner)
 
         runner.emit(RunnerEvent.Log("上一轮"))
-        recorder.beginSession(planOf("清体力"))
+        recorder.beginSession(planOf("清体力"), RecordingEventRunnerPort.DEFAULT_EXECUTION_ID)
         assertNull(recorder.lastUserFacing.value)
         assertNull(recorder.liveUpdateStatus.value)
-        recorder.endSession(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.endSession(
+            "execution-1",
+            RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+        )
     }
 
     @Test
@@ -204,9 +238,15 @@ class RunLogRecorderTest {
         val runner = RecordingEventRunnerPort()
         val recorder = recorder(runner)
 
-        recorder.begin(planOf("清体力"))
-        recorder.warn(com.aliothmoon.maafw.i18n.uiTextFromFramework("内存偏紧"))
-        recorder.end(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.begin(planOf("清体力"), RecordingEventRunnerPort.DEFAULT_EXECUTION_ID)
+        recorder.warn(
+            RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            com.aliothmoon.maafw.i18n.uiTextFromFramework("内存偏紧"),
+        )
+        recorder.end(
+            RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+        )
 
         val line = recorder.runLog.value.single()
         assertEquals(RunLogKind.Warning, line.kind)
@@ -217,13 +257,46 @@ class RunLogRecorderTest {
     }
 
     @Test
+    fun `old finalization and notes cannot take over the new session`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        recorder.beginSession(planOf("旧任务"), "execution-1")
+        recorder.beginSession(planOf("新任务"), "execution-2")
+        runner.emit(RunnerEvent.Log("新执行状态"), executionId = "execution-2")
+        recorder.warn("execution-1", UiText.Verbatim("旧执行警告"))
+        settleRunLog()
+
+        assertEquals("新执行状态", recorder.lastUserFacing.value)
+        assertTrue(recorder.runLog.value.none { it.text == UiText.Verbatim("旧执行警告") })
+        recorder.end("execution-1", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        runner.emit(RunnerEvent.Log("新执行仍在"), executionId = "execution-2")
+        recorder.end("execution-2", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+
+        val records = sessionRecordsFor("新任务")
+        assertEquals(
+            listOf("新任务"),
+            (records.first() as RunSessionRecord.Header).tasks,
+        )
+        val lines = records.filterIsInstance<RunSessionRecord.Line>().map { it.text }
+        assertEquals(listOf("新执行状态", "新执行仍在"), lines)
+        assertEquals(
+            RunSessionOutcome.COMPLETED,
+            (records.last() as RunSessionRecord.Footer).outcome,
+        )
+    }
+
+    @Test
     fun `a session writes header lines and footer`() = runTest(dispatcher) {
         val runner = RecordingEventRunnerPort()
         val recorder = recorder(runner)
 
-        recorder.beginSession(planOf("清体力", "签到"))
+        recorder.beginSession(planOf("清体力", "签到"), RecordingEventRunnerPort.DEFAULT_EXECUTION_ID)
         runner.emit(RunnerEvent.Log("跑起来了"))
-        recorder.endSession(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.endSession(
+            RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+        )
 
         val records = sessionRecords()
         assertEquals(listOf("清体力", "签到"), (records.first() as RunSessionRecord.Header).tasks)
@@ -234,14 +307,99 @@ class RunLogRecorderTest {
         )
     }
 
+    @Test
+    fun `endAfterDrain waits for a buffered failure before closing the file`() =
+        runTest(dispatcher) {
+            val recordingRunner = RecordingEventRunnerPort()
+            val runner = GatedRecordingRunnerPort(recordingRunner)
+            val recorder = recorder(runner)
+
+            recorder.beginSession(planOf("清体力"), RecordingEventRunnerPort.DEFAULT_EXECUTION_ID)
+            runner.hold()
+            runner.emit(
+                RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"清体力"}"""),
+                executionId = RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            )
+            runner.emit(
+                RunnerEvent.ExecutionFinished,
+                executionId = RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            )
+            val ending = async {
+                recorder.endAfterDrain(
+                    RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+                    RunEndReason.Ran(ExecutionResult.CompletedWithFailures(emptyList())),
+                )
+            }
+
+            assertTrue(ending.isActive)
+            runner.release()
+            advanceUntilIdle()
+            ending.await()
+
+            val records = sessionRecords()
+            assertEquals(
+                RunLogKind.Error,
+                records.filterIsInstance<RunSessionRecord.Line>().single().kind,
+            )
+            assertTrue(records.last() is RunSessionRecord.Footer)
+        }
+
+    @Test
+    fun `a new begin does not skip the old drain failing log`() =
+        runTest(dispatcher) {
+            val recordingRunner = RecordingEventRunnerPort()
+            val runner = GatedRecordingRunnerPort(recordingRunner)
+            val recorder = recorder(runner)
+
+            recorder.beginSession(planOf("旧任务"), "execution-1")
+            runner.hold()
+            runner.emit(
+                RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"旧任务"}"""),
+                executionId = "execution-1",
+            )
+            runner.emit(
+                RunnerEvent.ExecutionFinished,
+                executionId = "execution-1",
+            )
+            val oldEnding = async {
+                recorder.endAfterDrain(
+                    "execution-1",
+                    RunEndReason.Ran(ExecutionResult.CompletedWithFailures(emptyList())),
+                )
+            }
+
+            assertTrue(oldEnding.isActive)
+            recorder.beginSession(planOf("新任务"), "execution-2")
+            runner.release()
+            advanceUntilIdle()
+            oldEnding.await()
+            recorder.endSession(
+                "execution-2",
+                RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+            )
+
+            val records = sessionRecordsFor("旧任务")
+            assertEquals(
+                RunLogKind.Error,
+                records.filterIsInstance<RunSessionRecord.Line>().single().kind,
+            )
+            assertEquals(
+                RunSessionOutcome.COMPLETED_WITH_FAILURES,
+                (records.last() as RunSessionRecord.Footer).outcome,
+            )
+        }
+
     /** 没投出去也要留一份：「昨晚为什么没跑」是查这份日志的头号问题 */
     @Test
     fun `a round that never dispatched still gets a footer`() = runTest(dispatcher) {
         val runner = RecordingEventRunnerPort()
         val recorder = recorder(runner)
 
-        recorder.beginSession(planOf("清体力"))
-        recorder.endSession(RunEndReason.NotRun(NotRunCause.Rejected))
+        recorder.beginSession(planOf("清体力"), RecordingEventRunnerPort.DEFAULT_EXECUTION_ID)
+        recorder.endSession(
+            RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            RunEndReason.NotRun(NotRunCause.Rejected),
+        )
 
         assertEquals(
             RunSessionOutcome.NOT_RUN,
@@ -255,12 +413,15 @@ class RunLogRecorderTest {
         val runner = RecordingEventRunnerPort()
         val recorder = recorder(runner)
 
-        recorder.beginSession(planOf("a"))
+        recorder.beginSession(planOf("a"), RecordingEventRunnerPort.DEFAULT_EXECUTION_ID)
         runner.emit(RunnerEvent.Callback("Node.Action.Failed", """{"name":"A"}"""))
         includeDetails = true
         // 换个事件名：合成器按 kind + 正文去重，同名的第二条本来就到不了落盘这步
         runner.emit(RunnerEvent.Callback("Node.Recognition.Failed", """{"name":"B"}"""))
-        recorder.endSession(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.endSession(
+            RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+        )
 
         val lines = sessionRecords().filterIsInstance<RunSessionRecord.Line>()
         assertNull(lines[0].detail)
@@ -277,18 +438,189 @@ class RunLogRecorderTest {
         val runner = RecordingEventRunnerPort()
         val recorder = recorder(runner)
 
-        recorder.beginSession(planOf("a"))
-        runner.emit(RunnerEvent.Log("同一句"))
-        recorder.endSession(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.beginSession(planOf("a"), "execution-1")
+        runner.emit(RunnerEvent.Log("同一句"), executionId = "execution-1")
+        recorder.endSession("execution-1", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
 
         settleRunLog()
         val before = recorder.runLog.value.size
-        recorder.beginSession(planOf("a"))
-        runner.emit(RunnerEvent.Log("同一句"))
-        recorder.endSession(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.beginSession(planOf("a"), "execution-2")
+        runner.emit(RunnerEvent.Log("同一句"), executionId = "execution-2")
+        recorder.endSession("execution-2", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
         settleRunLog()
 
         assertTrue("跨轮被去重掉了", recorder.runLog.value.size > before)
+    }
+
+    @Test
+    fun `task entry labels do not borrow another task name`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        recorder.beginSession(
+            plan = planOf(
+                RuntimeTask("A", "Fight", emptyList(), label = "第一任务"),
+                RuntimeTask("Fight", "Other", emptyList(), label = "第二任务"),
+            ),
+            executionId = RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+        )
+        runner.emit(RunnerEvent.Callback("Tasker.Task.Succeeded", """{"entry":"Fight"}"""))
+        recorder.endSession(
+            RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+            RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+        )
+        settleRunLog()
+
+        assertEquals(
+            UiText.Resource(
+                R.string.run_log_task_succeeded,
+                listOf("第一任务"),
+            ),
+            recorder.runLog.value.single().text,
+        )
+    }
+
+    @Test
+    fun `a callback consumed after session end keeps its frozen label`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        recorder.beginSession(
+            planOf(RuntimeTask("A", "Fight", emptyList(), label = "战斗")),
+            executionId = "execution-1",
+        )
+        recorder.endSession("execution-1", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        runner.emit(
+            RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"Fight"}"""),
+            executionId = "execution-1",
+        )
+        settleRunLog()
+
+        assertEquals(
+            UiText.Resource(
+                R.string.run_log_task_failed,
+                listOf("战斗"),
+            ),
+            recorder.runLog.value.single().text,
+        )
+    }
+
+    @Test
+    fun `a stale essential event after both sessions end cannot replace final status`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        recorder.beginSession(planOf("旧任务"), "execution-1")
+        recorder.endSession("execution-1", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.beginSession(planOf("新任务"), "execution-2")
+        runner.emit(RunnerEvent.Log("新执行失败"), executionId = "execution-2")
+        recorder.endSession("execution-2", RunEndReason.Ran(ExecutionResult.Failed(
+            UiText.Verbatim("failed"),
+        )))
+
+        assertEquals("新执行失败", recorder.lastUserFacing.value)
+        runner.emit(
+            RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"旧任务"}"""),
+            executionId = "execution-1",
+        )
+        settleRunLog()
+
+        assertEquals("新执行失败", recorder.lastUserFacing.value)
+    }
+
+    @Test
+    fun `a stale essential event after a superseded session ends cannot replace final status`() =
+        runTest(dispatcher) {
+            val runner = RecordingEventRunnerPort()
+            val recorder = recorder(runner)
+
+            recorder.beginSession(planOf("旧任务"), "execution-1")
+            recorder.beginSession(planOf("新任务"), "execution-2")
+            runner.emit(RunnerEvent.Log("新执行状态"), executionId = "execution-2")
+            recorder.endSession("execution-2", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+
+            assertEquals("新执行状态", recorder.lastUserFacing.value)
+            runner.emit(
+                RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"旧任务"}"""),
+                executionId = "execution-1",
+            )
+            settleRunLog()
+
+            assertEquals("新执行状态", recorder.lastUserFacing.value)
+        }
+
+    @Test
+    fun `an old callback after the next begin is dropped from ui and file`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        recorder.beginSession(
+            plan = planOf(RuntimeTask("A", "Fight", emptyList(), label = "旧任务")),
+            executionId = "execution-1",
+        )
+        recorder.endSession("execution-1", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        recorder.beginSession(
+            plan = planOf(RuntimeTask("B", "Other", emptyList(), label = "新任务")),
+            executionId = "execution-2",
+        )
+        runner.emit(
+            RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"Fight"}"""),
+            executionId = "execution-1",
+        )
+        recorder.endSession("execution-2", RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        settleRunLog()
+
+        assertTrue(recorder.runLog.value.isEmpty())
+        assertNull(recorder.lastUserFacing.value)
+        val lines = sessionRecords().filterIsInstance<RunSessionRecord.Line>()
+        assertEquals(emptyList<RunSessionRecord.Line>(), lines)
+    }
+
+    @Test
+    fun `an evicted execution cannot reclaim the idle ui`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        repeat(9) { index ->
+            val executionId = "execution-$index"
+            recorder.beginSession(planOf("任务$index"), executionId)
+            recorder.endSession(
+                executionId,
+                RunEndReason.Ran(ExecutionResult.Completed(emptyList())),
+            )
+        }
+        runner.emit(
+            RunnerEvent.Callback("Tasker.Task.Failed", """{"entry":"任务0"}"""),
+            executionId = "execution-0",
+        )
+        settleRunLog()
+
+        assertNull(recorder.lastUserFacing.value)
+        assertTrue(recorder.runLog.value.isEmpty())
+    }
+
+    @Test
+    fun `an entry shared by differently named tasks stays unambiguous`() = runTest(dispatcher) {
+        val runner = RecordingEventRunnerPort()
+        val recorder = recorder(runner)
+
+        recorder.beginSession(
+            plan = planOf(
+                RuntimeTask("A", "Fight", emptyList(), label = "第一任务"),
+                RuntimeTask("B", "Fight", emptyList(), label = "第二任务"),
+            ),
+            executionId = RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+        )
+        runner.emit(RunnerEvent.Callback("Tasker.Task.Starting", """{"entry":"Fight"}"""))
+        settleRunLog()
+
+        assertEquals(
+            UiText.Resource(
+                R.string.run_log_task_starting,
+                listOf("Fight"),
+            ),
+            recorder.runLog.value.single().text,
+        )
     }
 
     /**
@@ -322,6 +654,40 @@ class RunLogRecorderTest {
         runConfigurationId = RunConfigurationId("cfg"),
         tasks = taskNames.map { RuntimeTask(taskName = it, entry = it, pipelineOverrides = emptyList()) },
     )
+
+    private fun planOf(vararg tasks: RuntimeTask) = RunPlan(
+        projectName = "demo",
+        projectVersion = "1",
+        controller = ControllerDefinition(),
+        resource = ResourceDefinition(name = "official", paths = listOf("resource"), label = "官服"),
+        runConfigurationId = RunConfigurationId("cfg"),
+        tasks = tasks.toList(),
+    )
+
+    private class GatedRecordingRunnerPort(
+        private val runner: RecordingEventRunnerPort,
+    ) : RunnerPort by runner {
+        @Volatile
+        private var gate = CompletableDeferred<Unit>()
+
+        override val events = runner.events.map { envelope ->
+            gate.await()
+            envelope
+        }
+
+        fun hold() {
+            gate = CompletableDeferred()
+        }
+
+        fun release() {
+            gate.complete(Unit)
+        }
+
+        fun emit(
+            event: RunnerEvent,
+            executionId: String = RecordingEventRunnerPort.DEFAULT_EXECUTION_ID,
+        ) = runner.emit(event, executionId)
+    }
 
     private companion object {
         /** FocusDispatcher 只拿它查 $i18n；本用例的 focus 不走翻译，空项目就够 */

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunLogTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunLogTest.kt
@@ -1,0 +1,16 @@
+package com.aliothmoon.maafw.runner
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RunLogTest {
+    @Test
+    fun `progress log text prefers the display label`() {
+        assertEquals("每日启动 1/3", RunnerEvent.Progress("internal", 1, 3, "每日启动").toLogText())
+    }
+
+    @Test
+    fun `progress log text falls back to the task name`() {
+        assertEquals("internal 1/3", RunnerEvent.Progress("internal", 1, 3).toLogText())
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunPlanBuilderTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunPlanBuilderTest.kt
@@ -71,6 +71,19 @@ class RunPlanBuilderTest {
     }
 
     @Test
+    fun `用户重命名优先于定义展示名并去掉空白`() {
+        val result = RunPlanBuilder.build(
+            definition,
+            configWith(ConfiguredTask("启动游戏", customLabel = "  每日启动  ")),
+        )
+        assertTrue("应编译成功: $result", result is RunPlanResult.Success)
+        assertEquals(
+            "每日启动",
+            (result as RunPlanResult.Success).plan.tasks.single().label,
+        )
+    }
+
+    @Test
     fun `夹具 PI 的 agent 声明原样冻结进 RunPlan`() {
         val result = RunPlanBuilder.build(definition, configWith(ConfiguredTask("启动游戏")))
         assertTrue("应编译成功: $result", result is RunPlanResult.Success)

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunSessionLogStoreTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunSessionLogStoreTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -71,6 +72,19 @@ class RunSessionLogStoreTest {
         assertEquals(3, info.taskCount)
         assertEquals(START / 1000, info.startedAt / 1000)
         assertTrue(info.sizeBytes > 0)
+    }
+
+    @Test
+    fun `same-second sessions with the same task count get distinct files`() = runBlocking {
+        checkNotNull(store.open(START, listOf("a"))).close()
+        checkNotNull(store.open(START, listOf("a"))).close()
+
+        val names = sessionFiles().map { it.name }
+        assertEquals(2, names.size)
+        assertNotEquals(names[0], names[1])
+        val summaries = store.list()
+        assertEquals(listOf(START, START), summaries.map { it.startedAt })
+        assertEquals(listOf(1, 1), summaries.map { it.taskCount })
     }
 
     /** 被杀进程会留下半行；那一行跳过就是了，不该毁掉前面几百条 */

--- a/app/src/test/java/com/aliothmoon/maafw/runner/StubRunnerPortTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/StubRunnerPortTest.kt
@@ -1,0 +1,49 @@
+package com.aliothmoon.maafw.runner
+
+import com.aliothmoon.maafw.domain.ControllerDefinition
+import com.aliothmoon.maafw.domain.ResourceDefinition
+import com.aliothmoon.maafw.domain.RunConfigurationId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StubRunnerPortTest {
+    @Test
+    fun `blank task labels fall back to the task name in progress`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = StubRunnerPort(
+                scope = backgroundScope,
+                scenario = StubRunnerScenario(
+                    prepareDelayMillis = 0,
+                    taskDelayMillis = 0,
+                ),
+            )
+            val events = mutableListOf<RunnerEventEnvelope>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                runner.events.collect { events += it }
+            }
+            advanceUntilIdle()
+
+            runner.start(PLAN, "execution-1")
+            advanceUntilIdle()
+
+            val progress = events.mapNotNull { it.event as? RunnerEvent.Progress }
+            assertEquals(listOf("启动游戏"), progress.map { it.taskLabel })
+        }
+
+    private companion object {
+        val PLAN = RunPlan(
+            projectName = "demo",
+            projectVersion = "1",
+            controller = ControllerDefinition(),
+            resource = ResourceDefinition(name = "official", paths = listOf("resource")),
+            runConfigurationId = RunConfigurationId("cfg"),
+            tasks = listOf(RuntimeTask("启动游戏", "Start", emptyList(), label = "")),
+        )
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/telemetry/TelemetryControllerTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/telemetry/TelemetryControllerTest.kt
@@ -1,0 +1,123 @@
+package com.aliothmoon.maafw.telemetry
+
+import android.content.Context
+import com.aliothmoon.maafw.domain.ControllerDefinition
+import com.aliothmoon.maafw.domain.ProjectDefinition
+import com.aliothmoon.maafw.domain.ResourceDefinition
+import com.aliothmoon.maafw.domain.RunConfigurationId
+import com.aliothmoon.maafw.domain.TelemetryDefinition
+import com.aliothmoon.maafw.domain.TaskGroupDefinition
+import com.aliothmoon.maafw.project.FakeProjectRepository
+import com.aliothmoon.maafw.project.ProjectState
+import com.aliothmoon.maafw.runner.FocusChannel
+import com.aliothmoon.maafw.runner.FocusDispatcher
+import com.aliothmoon.maafw.runner.FocusMessage
+import com.aliothmoon.maafw.runner.PassthroughFocusContentResolver
+import com.aliothmoon.maafw.runner.RecordingEventRunnerPort
+import com.aliothmoon.maafw.runner.RunPlan
+import com.aliothmoon.maafw.runner.RunnerEvent
+import com.aliothmoon.maafw.settings.FakeAppSettingsGateway
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+import io.sentry.android.core.SentryAndroid
+import io.sentry.android.core.SentryAndroidOptions
+import io.sentry.protocol.SentryId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TelemetryControllerTest {
+
+    @Test
+    fun `traced focus from an old execution is ignored after a new run starts`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val runner = RecordingEventRunnerPort()
+            val settings = FakeAppSettingsGateway().apply { telemetryEnabled.value = true }
+            val focusDispatcher = FocusDispatcher(
+                projectRepository = FakeProjectRepository(ProjectState.Ready(DEFINITION, emptyList())),
+                resolver = PassthroughFocusContentResolver,
+                runnerPort = runner,
+                scope = backgroundScope,
+            )
+            val controller = TelemetryController(
+                context = mockk<Context>(),
+                projectRepository = FakeProjectRepository(ProjectState.Ready(DEFINITION, emptyList())),
+                settings = settings,
+                focusDispatcher = focusDispatcher,
+                runnerPort = runner,
+                scope = backgroundScope,
+            )
+
+            mockkStatic(Sentry::class)
+            mockkStatic(SentryAndroid::class)
+            try {
+                every {
+                    Sentry.captureMessage(any<String>(), any<SentryLevel>())
+                } returns SentryId("00000000-0000-0000-0000-000000000000")
+                every {
+                    SentryAndroid.init(
+                        any<Context>(),
+                        any<Sentry.OptionsConfiguration<SentryAndroidOptions>>(),
+                    )
+                } just Runs
+
+                controller.setup()
+                runner.prepare(PLAN, "execution-1")
+                runner.emit(tracedFocus("old-event"), executionId = "execution-1")
+                runner.prepare(PLAN, "execution-2")
+                runner.emit(tracedFocus("late-old-event"), executionId = "execution-1")
+                runner.emit(tracedFocus("new-event"), executionId = "execution-2")
+                advanceUntilIdle()
+
+                verify(exactly = 1) { Sentry.captureMessage("old-event", SentryLevel.INFO) }
+                verify(exactly = 1) { Sentry.captureMessage("new-event", SentryLevel.INFO) }
+                verify(exactly = 0) {
+                    Sentry.captureMessage("late-old-event", any<SentryLevel>())
+                }
+            } finally {
+                io.mockk.unmockkStatic(Sentry::class)
+                io.mockk.unmockkStatic(SentryAndroid::class)
+            }
+        }
+
+    private fun tracedFocus(message: String) = RunnerEvent.Focus(
+        FocusMessage(
+            message = message,
+            content = "",
+            channels = setOf(FocusChannel.Log),
+            trace = true,
+        ),
+    )
+
+    private companion object {
+        val DEFINITION = ProjectDefinition(
+            name = "demo",
+            version = "1.0",
+            controller = ControllerDefinition(),
+            resources = emptyList(),
+            tasks = emptyList(),
+            groups = listOf(TaskGroupDefinition(name = "ungrouped", isUngrouped = true)),
+            options = emptyMap(),
+            templates = emptyList(),
+            telemetry = TelemetryDefinition(dsn = "https://example.invalid", tracing = false),
+        )
+
+        val PLAN = RunPlan(
+            projectName = "demo",
+            projectVersion = "1.0",
+            controller = ControllerDefinition(),
+            resource = ResourceDefinition(name = "official", paths = listOf("resource")),
+            runConfigurationId = RunConfigurationId("cfg"),
+            tasks = emptyList(),
+        )
+    }
+}


### PR DESCRIPTION
## 概要

- 串行分发 Runner 回调，避免终局事件抢在排队中的运行事件之前到达
- 使用执行 ID 关联 Runner、Focus、界面和会话文件日志
- 在关闭会话前等待待处理事件，并保持任务标签与状态显示稳定
- 增加针对过期执行、回调顺序、会话文件冲突和遥测的测试覆盖

## 测试

- `./gradlew testDebugUnitTest`