### PR TITLE
fix: use the framework default for save-on-error

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/maa/MaaFrameworkLibrary.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/maa/MaaFrameworkLibrary.kt
@@ -130,7 +130,6 @@ object MaaGlobalOption {
     const val SAVE_DRAW = 2
     const val STDOUT_LEVEL = 4
     const val DEBUG_MODE = 6
-    const val SAVE_ON_ERROR = 7
 }
 
 /** `MaaLoggingLevelEnum` */

--- a/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunner.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/MaaRunner.kt
@@ -140,8 +140,6 @@ class MaaRunner(private val agentHost: AgentHost) {
             MaaGlobalOption.STDOUT_LEVEL,
             if (debug) MaaLoggingLevel.INFO else MaaLoggingLevel.ERROR,
         )
-        // 节点出错时自动存一张现场图，比事后复现便宜；SAVE_DRAW 会每次识别都写盘，暂不开
-        setBoolOption(lib, MaaGlobalOption.SAVE_ON_ERROR, debug)
         Ln.i("MaaRunner: global options applied, logDir=$logDir debug=$debug")
     }
 
@@ -157,12 +155,6 @@ class MaaRunner(private val agentHost: AgentHost) {
         val memory = Memory(Int.SIZE_BYTES.toLong())
         memory.setInt(0, value)
         return lib.MaaGlobalSetOption(key, memory, Int.SIZE_BYTES.toLong()).toInt() != 0
-    }
-
-    private fun setBoolOption(lib: MaaFrameworkLibrary, key: Int, value: Boolean): Boolean {
-        val memory = Memory(1)
-        memory.setByte(0, if (value) 1 else 0)
-        return lib.MaaGlobalSetOption(key, memory, 1).toInt() != 0
     }
 
     fun isRunning(): Boolean = synchronized(lifecycleLock) { running }


### PR DESCRIPTION
## 变更

- 移除 App 侧对 MaaFramework `SAVE_ON_ERROR` 的显式设置
- 删除随之不再使用的常量和布尔选项写入辅助函数

## 原因

`SAVE_ON_ERROR` 应遵循 MaaFramework 的默认行为，不再与 App 的调试模式绑定；调试模式仍只控制日志级别和 logcat 抓取。

## 验证

- `rtk ./gradlew :app:compileDebugKotlin`
- `rtk git diff --check`