### PR TITLE
feat: 清理诊断数据并重启应用

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/di/LogModule.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/di/LogModule.kt
@@ -5,6 +5,7 @@ import com.aliothmoon.maafw.constant.AppPaths
 import com.aliothmoon.maafw.log.AppLogWriter
 import com.aliothmoon.maafw.log.DeviceInfoCollector
 import com.aliothmoon.maafw.log.DeviceInfoText
+import com.aliothmoon.maafw.log.LogCleanupService
 import com.aliothmoon.maafw.log.LogExportService
 import com.aliothmoon.maafw.settings.AppSettingsManager
 import org.koin.android.ext.koin.androidContext
@@ -12,6 +13,12 @@ import org.koin.dsl.module
 
 val logModule = module {
     single { AppLogWriter() }
+    single {
+        LogCleanupService(
+            appLogWriter = get(),
+            roots = { listOf(AppPaths.LOG_DIR, AppPaths.DEBUG_DIR) },
+        )
+    }
     single {
         val context = androidContext()
         LogExportService(

--- a/app/src/main/java/com/aliothmoon/maafw/log/LogCleanupService.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/log/LogCleanupService.kt
@@ -1,0 +1,19 @@
+package com.aliothmoon.maafw.log
+
+import com.aliothmoon.maafw.MaaDispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/** Clears all diagnostic products before an app restart. */
+class LogCleanupService(
+    private val appLogWriter: AppLogWriter,
+    private val roots: () -> List<File>,
+) {
+
+    suspend fun clearAll(): Boolean = withContext(MaaDispatchers.IO) {
+        appLogWriter.purge().join()
+        roots()
+            .map { root -> !root.exists() || root.deleteRecursively() }
+            .all { it }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
@@ -342,6 +342,7 @@ sealed interface SessionIntent {
     data object RefreshPermissions : SessionIntent
 
     data object ClearRunLog : SessionIntent
+    data object ClearDiagnosticData : SessionIntent
 }
 
 /** 一次性 Effect，不进 UiState */

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -48,6 +48,7 @@ import com.aliothmoon.maafw.theme.ThemeStyle
 import com.aliothmoon.maafw.i18n.uiTextFormatted
 import com.aliothmoon.maafw.i18n.uiTextFromProject
 import com.aliothmoon.maafw.i18n.uiTextOf
+import com.aliothmoon.maafw.log.LogCleanupService
 import com.aliothmoon.maafw.ui.i18n.diagnosticsSummaryUiText
 import com.aliothmoon.maafw.settings.AppSettingsGateway
 import com.aliothmoon.maafw.telemetry.isDebugProjectVersion
@@ -117,6 +118,8 @@ class SessionViewModel(
     private val focusDispatcher: FocusDispatcher,
     /** 运行日志的产地；VM 只转发它的流并转达「清空」 */
     private val recorder: RunLogRecorder,
+    /** 诊断产物清空后必须重启，让日志管线拿到新的完整上文 */
+    private val logCleanup: LogCleanupService,
     private val piInstall: PiInstallCoordinator,
 ) : ViewModel() {
 
@@ -541,6 +544,14 @@ class SessionViewModel(
             SessionIntent.RefreshPermissions -> permissionGateway.refresh()
 
             SessionIntent.ClearRunLog -> recorder.clear()
+
+            SessionIntent.ClearDiagnosticData -> guarded {
+                if (logCleanup.clearAll()) {
+                    emitEffect(SessionEffect.RestartApp)
+                } else {
+                    emitEffect(SessionEffect.ShowMessage(uiTextOf(R.string.settings_log_cleanup_failed)))
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maafw/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.provider.Settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -20,6 +21,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.AlertDialog
@@ -74,6 +76,7 @@ import com.aliothmoon.maafw.ui.components.MaaLabeledControlRow
 import com.aliothmoon.maafw.ui.components.MaaMarkdown
 import com.aliothmoon.maafw.ui.components.MaaMarkdownSheet
 import com.aliothmoon.maafw.ui.components.MaaNavigationRow
+import com.aliothmoon.maafw.ui.components.MaaSemanticOutlinedButton
 import com.aliothmoon.maafw.ui.components.MaaSingleChoiceFlow
 import com.aliothmoon.maafw.ui.components.MaaSwitch
 import com.aliothmoon.maafw.ui.components.MaaSwitchRow
@@ -319,6 +322,7 @@ private fun LogCard(
     onExportLogs: () -> Unit,
 ) {
     var showEnableConfirm by remember { mutableStateOf(false) }
+    var showCleanupConfirm by remember { mutableStateOf(false) }
     MaaCard(title = stringResource(R.string.settings_section_log), collapsible = true) {
         MaaNavigationRow(
             label = stringResource(R.string.log_archive_title),
@@ -334,6 +338,27 @@ private fun LogCard(
             label = stringResource(R.string.log_export_title),
             description = stringResource(R.string.settings_log_export_desc),
             onClick = onExportLogs,
+        )
+        MaaSemanticOutlinedButton(
+            onClick = { showCleanupConfirm = true },
+            enabled = !state.configurationLocked,
+            semantic = MaterialTheme.colorScheme.error,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(MaaDesignTokens.ButtonHeight.prominent),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.DeleteOutline,
+                contentDescription = null,
+                modifier = Modifier.size(MaaDesignTokens.IconSize.md),
+            )
+            Box(Modifier.size(MaaDesignTokens.Spacing.sm))
+            Text(stringResource(R.string.settings_log_cleanup))
+        }
+        Text(
+            text = stringResource(R.string.settings_log_cleanup_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         // 启用走确认弹窗，确认即落盘 + 重启 App（对齐 MaaMeow）；关闭直接关
         MaaLabeledControlRow(
@@ -367,6 +392,24 @@ private fun LogCard(
             },
             dismissButton = {
                 TextButton(onClick = { showEnableConfirm = false }) {
+                    Text(stringResource(R.string.dialog_cancel))
+                }
+            },
+        )
+    }
+    if (showCleanupConfirm) {
+        AlertDialog(
+            onDismissRequest = { showCleanupConfirm = false },
+            title = { Text(stringResource(R.string.settings_log_cleanup_title)) },
+            text = { Text(stringResource(R.string.settings_log_cleanup_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showCleanupConfirm = false
+                    onIntent(SessionIntent.ClearDiagnosticData)
+                }) { Text(stringResource(R.string.settings_log_cleanup_confirm)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCleanupConfirm = false }) {
                     Text(stringResource(R.string.dialog_cancel))
                 }
             },

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -515,6 +515,12 @@
     <string name="settings_log_archive_desc">View the execution log of each run</string>
     <string name="settings_log_error_desc">View the app\'s own exceptions and errors</string>
     <string name="settings_log_export_desc">Pack all logs into a ZIP file to share</string>
+    <string name="settings_log_cleanup">Clear diagnostic data</string>
+    <string name="settings_log_cleanup_desc">Delete app and MaaFramework logs, run records, screenshots, and diagnostic files</string>
+    <string name="settings_log_cleanup_title">Clear diagnostic data</string>
+    <string name="settings_log_cleanup_message">All logs, run records, screenshots, and diagnostic files will be deleted, then the app will restart. This cannot be undone.</string>
+    <string name="settings_log_cleanup_confirm">Clear and restart</string>
+    <string name="settings_log_cleanup_failed">Failed to clear logs</string>
 
     <!-- Diagnostic texts; built by DiagnosticMessages in domain/Diagnostics.kt -->
     <string name="diagnostic_severity_warning">Warning</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,6 +506,12 @@
     <string name="settings_log_archive_desc">查看每次运行的执行日志</string>
     <string name="settings_log_error_desc">查看应用异常和错误记录</string>
     <string name="settings_log_export_desc">打包所有日志为 ZIP 文件分享</string>
+    <string name="settings_log_cleanup">清理日志数据</string>
+    <string name="settings_log_cleanup_desc">删除应用与 MaaFramework 日志、运行记录、截图和诊断文件</string>
+    <string name="settings_log_cleanup_title">清理日志数据</string>
+    <string name="settings_log_cleanup_message">将删除全部日志、运行记录、截图和诊断文件，并重启应用。此操作无法撤销。</string>
+    <string name="settings_log_cleanup_confirm">清理并重启</string>
+    <string name="settings_log_cleanup_failed">清理日志失败</string>
 
     <!-- 诊断文案；构造点在 domain/Diagnostics.kt 的 DiagnosticMessages -->
     <string name="diagnostic_severity_warning">警告</string>

--- a/app/src/test/java/com/aliothmoon/maafw/log/LogCleanupServiceTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/log/LogCleanupServiceTest.kt
@@ -1,0 +1,76 @@
+package com.aliothmoon.maafw.log
+
+import com.aliothmoon.maafw.MaaDispatchers
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class LogCleanupServiceTest {
+
+    private lateinit var base: File
+    private val writer = mockk<AppLogWriter>()
+
+    @Before
+    fun setUp() {
+        base = createTempDirectory("log-cleanup").toFile()
+        mockkObject(MaaDispatchers)
+        every { MaaDispatchers.IO } returns Dispatchers.Unconfined
+        every { writer.purge() } returns Job().apply { complete() }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(MaaDispatchers)
+        base.deleteRecursively()
+    }
+
+    @Test
+    fun `clearing removes both diagnostic roots after closing app logs`() = runBlocking {
+        write("log/app.log")
+        write("log/run/run_a.jsonl")
+        write("log/focus/focus_a.png")
+        write("debug/logcat/app/logcat_a.log")
+        write("debug/root_launch_debug.log")
+        write("pi/framework.so")
+        val service = service()
+
+        assertTrue(service.clearAll())
+
+        assertFalse(File(base, "log").exists())
+        assertFalse(File(base, "debug").exists())
+        assertTrue(File(base, "pi/framework.so").exists())
+        verify(exactly = 1) { writer.purge() }
+    }
+
+    @Test
+    fun `missing roots are treated as cleared`() = runBlocking {
+        val service = LogCleanupService(writer) {
+            listOf(File(base, "log"), File(base, "debug"))
+        }
+
+        assertTrue(service.clearAll())
+    }
+
+    private fun service() = LogCleanupService(writer) {
+        listOf(File(base, "log"), File(base, "debug"))
+    }
+
+    private fun write(path: String) {
+        File(base, path).apply {
+            parentFile?.mkdirs()
+            writeText("diagnostic")
+        }
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -17,6 +17,7 @@ import com.aliothmoon.maafw.domain.UserConfiguration
 import com.aliothmoon.maafw.R
 import com.aliothmoon.maafw.i18n.AppLocales
 import com.aliothmoon.maafw.i18n.isResource
+import com.aliothmoon.maafw.log.LogCleanupService
 import com.aliothmoon.maafw.privileged.FakeDisplaySizeGateway
 import com.aliothmoon.maafw.privileged.FakePermissionGateway
 import com.aliothmoon.maafw.privileged.FakePrivilegedServicePort
@@ -60,8 +61,11 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
@@ -183,6 +187,7 @@ class SessionViewModelTest {
         settings: FakeAppSettingsGateway = FakeAppSettingsGateway(),
         displaySize: FakeDisplaySizeGateway = FakeDisplaySizeGateway(),
         preview: RecordingPreviewPort = RecordingPreviewPort(),
+        cleanup: LogCleanupService = successfulCleanup(),
     ): Triple<SessionViewModel, InMemoryUserConfigurationStore, StubRunnerPort> {
         val focusDispatcher = idleFocusDispatcher()
         val vm = SessionViewModel(
@@ -197,6 +202,7 @@ class SessionViewModelTest {
             appSettings = settings,
             focusDispatcher = focusDispatcher,
             recorder = recorderFor(runner, focusDispatcher),
+            logCleanup = cleanup,
             piInstall = emptyPiInstall(),
         )
         return Triple(vm, store, runner)
@@ -210,6 +216,7 @@ class SessionViewModelTest {
         val project = FakeProjectRepository(ProjectState.Ready(definition, emptyList()))
         val store = readyStore()
         val settings = FakeAppSettingsGateway()
+        val cleanup = successfulCleanup()
         return SessionViewModel(
             projectRepository = project,
             configurationStore = store,
@@ -222,6 +229,7 @@ class SessionViewModelTest {
             appSettings = settings,
             focusDispatcher = focusDispatcher,
             recorder = recorderFor(runner, focusDispatcher),
+            logCleanup = cleanup,
             piInstall = emptyPiInstall(),
         )
     }
@@ -249,6 +257,11 @@ class SessionViewModelTest {
      */
     private fun emptyPiInstall() =
         PiInstallCoordinator(PiInstaller(EmptyPiPackage, versionCode = 1))
+
+    private fun successfulCleanup(): LogCleanupService =
+        mockk<LogCleanupService>().also {
+            coEvery { it.clearAll() } returns true
+        }
 
     /** 不接任何 RunnerPort 的 dispatcher：focus 的补完另有 FocusDispatcherTest 覆盖 */
     private fun TestScope.idleFocusDispatcher(
@@ -426,6 +439,71 @@ class SessionViewModelTest {
             effects.any {
                 it is SessionEffect.ShowMessage &&
                     it.message.isResource(R.string.msg_locked_while_running)
+            },
+        )
+    }
+
+    @Test
+    fun `clearing diagnostic data restarts after a successful cleanup`() = runTest(mainDispatcher) {
+        val cleanup = mockk<LogCleanupService>()
+        coEvery { cleanup.clearAll() } returns true
+        val (vm, _, _) = createVm(cleanup = cleanup)
+        advanceUntilIdle()
+        val effects = mutableListOf<SessionEffect>()
+        backgroundScope.launch { vm.effects.collect { effects += it } }
+
+        vm.onIntent(SessionIntent.ClearDiagnosticData)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { cleanup.clearAll() }
+        assertTrue(SessionEffect.RestartApp in effects)
+    }
+
+    @Test
+    fun `busy runner rejects diagnostic cleanup`() = runTest(mainDispatcher) {
+        val runner = StubRunnerPort(
+            scope = backgroundScope,
+            scenario = StubRunnerScenario(prepareDelayMillis = 60_000, taskDelayMillis = 60_000),
+        )
+        val cleanup = mockk<LogCleanupService>()
+        coEvery { cleanup.clearAll() } returns true
+        val (vm, _, _) = createVm(runner = runner, cleanup = cleanup)
+        advanceUntilIdle()
+        val effects = mutableListOf<SessionEffect>()
+        backgroundScope.launch { vm.effects.collect { effects += it } }
+
+        vm.onIntent(SessionIntent.Start())
+        advanceUntilIdle()
+        vm.onIntent(SessionIntent.ClearDiagnosticData)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { cleanup.clearAll() }
+        assertTrue(SessionEffect.RestartApp !in effects)
+        assertTrue(
+            effects.any {
+                it is SessionEffect.ShowMessage &&
+                    it.message.isResource(R.string.msg_locked_while_running)
+            },
+        )
+    }
+
+    @Test
+    fun `a failed diagnostic cleanup shows an error and does not restart`() = runTest(mainDispatcher) {
+        val cleanup = mockk<LogCleanupService>()
+        coEvery { cleanup.clearAll() } returns false
+        val (vm, _, _) = createVm(cleanup = cleanup)
+        advanceUntilIdle()
+        val effects = mutableListOf<SessionEffect>()
+        backgroundScope.launch { vm.effects.collect { effects += it } }
+
+        vm.onIntent(SessionIntent.ClearDiagnosticData)
+        advanceUntilIdle()
+
+        assertTrue(SessionEffect.RestartApp !in effects)
+        assertTrue(
+            effects.any {
+                it is SessionEffect.ShowMessage &&
+                    it.message.isResource(R.string.settings_log_cleanup_failed)
             },
         )
     }


### PR DESCRIPTION
## 摘要
- 在设置页新增“清理日志数据”入口，删除 log/debug 两类诊断产物
- 清理成功后重启应用；任务运行中拒绝操作，失败时给出提示
- 补充日志清理服务和 Session ViewModel 的单元测试

## 测试
- > Task :build-logic:convention:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :build-logic:convention:compileKotlin UP-TO-DATE
> Task :build-logic:convention:compileJava NO-SOURCE
> Task :build-logic:convention:pluginDescriptors UP-TO-DATE
> Task :build-logic:convention:processResources UP-TO-DATE
> Task :build-logic:convention:classes UP-TO-DATE
> Task :build-logic:convention:jar UP-TO-DATE

> Configure project :app
Build version: applicationId=com.aliothmoon.maafw.man, versionCode=35, versionName=1.3.49

> Task :semi-icons:preBuild UP-TO-DATE
> Task :hidden-api:preBuild UP-TO-DATE
> Task :annotation-api:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :semi-icons:preDebugBuild UP-TO-DATE
> Task :hidden-api:preDebugBuild UP-TO-DATE
> Task :ksp-processor:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :semi-icons:processDebugNavigationResources UP-TO-DATE
> Task :ksp-processor:processResources UP-TO-DATE
> Task :hidden-api:generateDebugResources UP-TO-DATE
> Task :semi-icons:generateDebugResources UP-TO-DATE
> Task :hidden-api:packageDebugResources UP-TO-DATE
> Task :semi-icons:packageDebugResources UP-TO-DATE
> Task :hidden-api:processDebugNavigationResources UP-TO-DATE
> Task :semi-icons:parseDebugLocalResources UP-TO-DATE
> Task :hidden-api:parseDebugLocalResources UP-TO-DATE
> Task :hidden-api:generateDebugRFile UP-TO-DATE
> Task :semi-icons:generateDebugRFile UP-TO-DATE
> Task :hidden-api:compileDebugKotlin NO-SOURCE
> Task :hidden-api:javaPreCompileDebug UP-TO-DATE
> Task :hidden-api:compileDebugJavaWithJavac UP-TO-DATE
> Task :hidden-api:bundleLibCompileToJarDebug UP-TO-DATE
> Task :annotation-api:compileKotlin UP-TO-DATE
> Task :annotation-api:compileJava NO-SOURCE
> Task :annotation-api:processResources NO-SOURCE
> Task :annotation-api:classes UP-TO-DATE
> Task :annotation-api:jar UP-TO-DATE
> Task :app:syncPiAssets UP-TO-DATE
> Task :app:packPiArchive UP-TO-DATE
> Task :app:syncAgentJniLibs UP-TO-DATE
> Task :app:syncProfileIcon UP-TO-DATE
> Task :ksp-processor:compileKotlin UP-TO-DATE
> Task :ksp-processor:compileJava NO-SOURCE
> Task :ksp-processor:classes UP-TO-DATE
> Task :ksp-processor:jar UP-TO-DATE
> Task :app:packAgentBundles UP-TO-DATE
> Task :app:writeAgentDescriptor UP-TO-DATE
> Task :semi-icons:compileDebugKotlin UP-TO-DATE
> Task :app:syncAgentAssets UP-TO-DATE
> Task :app:writeAgentIndex UP-TO-DATE
> Task :semi-icons:javaPreCompileDebug UP-TO-DATE
> Task :semi-icons:compileDebugJavaWithJavac NO-SOURCE
> Task :app:writeProfileSplash UP-TO-DATE
> Task :semi-icons:bundleLibCompileToJarDebug UP-TO-DATE
> Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild UP-TO-DATE
> Task :semi-icons:writeDebugAarMetadata UP-TO-DATE
> Task :semi-icons:extractDeepLinksDebug UP-TO-DATE
> Task :semi-icons:processDebugManifest UP-TO-DATE
> Task :semi-icons:mapDebugSourceSetPaths UP-TO-DATE
> Task :semi-icons:compileDebugLibraryResources UP-TO-DATE
> Task :semi-icons:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :semi-icons:processDebugJavaRes UP-TO-DATE
> Task :app:compileDebugAidl UP-TO-DATE
> Task :app:generateDebugBuildConfig
> Task :app:generateDebugResources UP-TO-DATE
> Task :app:packageDebugResources UP-TO-DATE
> Task :app:processDebugNavigationResources UP-TO-DATE
> Task :app:parseDebugLocalResources UP-TO-DATE
> Task :app:generateDebugRFile UP-TO-DATE
> Task :app:javaPreCompileDebug UP-TO-DATE
> Task :app:checkDebugAarMetadata UP-TO-DATE
> Task :app:mapDebugSourceSetPaths UP-TO-DATE
> Task :app:compileDebugNavigationResources UP-TO-DATE
> Task :app:mergeDebugResources UP-TO-DATE
> Task :app:createDebugCompatibleScreenManifests
> Task :app:extractDeepLinksDebug UP-TO-DATE
> Task :app:processDebugMainManifest FROM-CACHE
> Task :app:processDebugManifest FROM-CACHE
> Task :app:processDebugManifestForPackage FROM-CACHE
> Task :app:preDebugUnitTestBuild UP-TO-DATE
> Task :app:javaPreCompileDebugUnitTest UP-TO-DATE
> Task :app:processDebugResources
> Task :app:kspDebugKotlin
> Task :app:compileDebugKotlin
> Task :app:compileDebugJavaWithJavac
> Task :app:processDebugJavaRes UP-TO-DATE
> Task :app:bundleDebugClassesToCompileJar
> Task :app:bundleDebugClassesToRuntimeJar
> Task :app:kspDebugUnitTestKotlin
> Task :app:compileDebugUnitTestKotlin
> Task :app:compileDebugUnitTestJavaWithJavac NO-SOURCE
> Task :app:processDebugUnitTestJavaRes UP-TO-DATE
> Task :app:testDebugUnitTest

BUILD SUCCESSFUL in 16s
70 actionable tasks: 11 executed, 3 from cache, 56 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html（450 个执行，2 个跳过）