### PR TITLE
feat: warn when schedules run in foreground mode

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/runner/ForegroundModePrecheck.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/ForegroundModePrecheck.kt
@@ -14,7 +14,7 @@ object ForegroundModePrecheck : RunPrecheck {
 
     override suspend fun evaluate(ctx: RunContext): Verdict =
         if (ctx.runMode == RunMode.FOREGROUND && ctx.trigger is RunTrigger.Schedule) {
-            Verdict.Block(uiTextOf(R.string.runner_foreground_blocked))
+            Verdict.Block(uiTextOf(R.string.runner_foreground_schedule_blocked))
         } else {
             Verdict.Pass
         }

--- a/app/src/main/java/com/aliothmoon/maafw/schedule/ScheduleContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/schedule/ScheduleContracts.kt
@@ -1,5 +1,7 @@
 package com.aliothmoon.maafw.schedule
 
+import com.aliothmoon.maafw.domain.RunMode
+
 /** 一条规则加上它算出来的下次触发时刻；后者不落盘，每次由闹钟规则现算 */
 data class ScheduleRow(
     val strategy: ScheduleStrategy,
@@ -16,6 +18,7 @@ data class ScheduleConfigurationOption(
 )
 
 data class ScheduleUiState(
+    val runMode: RunMode = RunMode.BACKGROUND,
     val rows: List<ScheduleRow> = emptyList(),
     /** 可绑定的运行配置；空 = 用户还没建过 */
     val configurations: List<ScheduleConfigurationOption> = emptyList(),

--- a/app/src/main/java/com/aliothmoon/maafw/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/schedule/ScheduleExecutionService.kt
@@ -180,10 +180,14 @@ class ScheduleExecutionService : Service() {
             Timber.i("Schedule %s duplicate delivery, dropped", strategy.id)
             return
         }
-        if (outcome.result != TriggerResult.STARTED) {
-            Timber.w("Schedule %s did not start: %s", strategy.id, launchResult)
-        }
         val frozen = outcome.detail?.resolve(this)?.takeIf { it.isNotBlank() }
+        if (outcome.result != TriggerResult.STARTED) {
+            Timber.w(
+                "Schedule %s did not start: %s",
+                strategy.id,
+                frozen ?: launchResult.toString(),
+            )
+        }
 
         triggerLog.append(
             TriggerLogEntry(

--- a/app/src/main/java/com/aliothmoon/maafw/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/schedule/ScheduleViewModel.kt
@@ -2,6 +2,7 @@ package com.aliothmoon.maafw.schedule
 
 import androidx.lifecycle.ViewModel
 import com.aliothmoon.maafw.config.UserConfigurationStore
+import com.aliothmoon.maafw.settings.AppSettingsGateway
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +36,7 @@ class ScheduleViewModel(
     private val alarms: ScheduleAlarmManager,
     private val triggerLog: ScheduleTriggerLog,
     configurationStore: UserConfigurationStore,
+    appSettings: AppSettingsGateway,
 ) : ViewModel() {
 
     private val exactAlarmAllowed = MutableStateFlow(alarms.canScheduleExact())
@@ -54,8 +56,10 @@ class ScheduleViewModel(
         exactAlarmAllowed,
         loadedLog,
         configurations,
-    ) { strategies, exact, log, configs ->
+        appSettings.runMode,
+    ) { strategies, exact, log, configs, mode ->
         ScheduleUiState(
+            runMode = mode,
             rows = strategies.map { strategy ->
                 val missing = configs.options.none { it.id == strategy.runConfigurationId }
                 ScheduleRow(

--- a/app/src/main/java/com/aliothmoon/maafw/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/schedule/ScheduleScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import com.aliothmoon.maafw.R
+import com.aliothmoon.maafw.domain.RunMode
 import com.aliothmoon.maafw.schedule.ScheduleIntent
 import com.aliothmoon.maafw.schedule.ScheduleRow
 import com.aliothmoon.maafw.schedule.ScheduleUiState
@@ -104,6 +105,15 @@ fun ScheduleScreen(
             ),
         )
         // 空状态靠 fillParentMaxSize 居中，卡片不能再进列表
+        if (state.runMode == RunMode.FOREGROUND) {
+            ForegroundModeCard(
+                modifier = Modifier.padding(
+                    start = MaaDesignTokens.Spacing.lg,
+                    end = MaaDesignTokens.Spacing.lg,
+                    bottom = MaaDesignTokens.Spacing.md,
+                ),
+            )
+        }
         if (!state.exactAlarmAllowed) {
             ExactAlarmCard(
                 onGrant = { onIntent(ScheduleIntent.RequestExactAlarmPermission) },
@@ -138,6 +148,20 @@ fun ScheduleScreen(
         }
     }
 
+}
+
+@Composable
+private fun ForegroundModeCard(modifier: Modifier = Modifier) {
+    MaaCard(
+        modifier = modifier,
+        title = stringResource(R.string.schedule_foreground_reminder_title),
+    ) {
+        Text(
+            text = stringResource(R.string.schedule_foreground_reminder_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -266,6 +266,8 @@
     <string name="schedule_next_trigger">Next %1$s</string>
     <string name="schedule_next_none">Incomplete rule, will not fire</string>
     <string name="schedule_disabled">Disabled</string>
+    <string name="schedule_foreground_reminder_title">Foreground mode only supports scheduled reminders</string>
+    <string name="schedule_foreground_reminder_hint">Switch to background mode to use automatic starts</string>
     <string name="schedule_exact_alarm_blocked">Exact alarms are not allowed</string>
     <string name="schedule_exact_alarm_hint">Schedules still fire on time, but the status bar shows an alarm icon</string>
     <string name="schedule_exact_alarm_grant">Allow</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -43,6 +43,7 @@
     <!-- Runner toggle -->
     <string name="runner_start">Start tasks</string>
     <string name="runner_foreground_blocked">Foreground mode is active; switch to background mode first</string>
+    <string name="runner_foreground_schedule_blocked">Foreground mode does not auto-start scheduled runs; switch to background mode to run them automatically</string>
     <string name="runner_stop">Stop</string>
     <string name="runner_stopping">Stopping…</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,8 @@
     <string name="schedule_next_trigger">下次 %1$s</string>
     <string name="schedule_next_none">规则不完整，不会触发</string>
     <string name="schedule_disabled">已停用</string>
+    <string name="schedule_foreground_reminder_title">前台模式仅支持到点提醒功能</string>
+    <string name="schedule_foreground_reminder_hint">如需使用自动启动，请切换为后台模式</string>
     <string name="schedule_exact_alarm_blocked">系统未允许精确闹钟</string>
     <string name="schedule_exact_alarm_hint">仍会按时触发，但状态栏会多一个闹钟图标</string>
     <string name="schedule_exact_alarm_grant">去允许</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <!-- 运行开关 -->
     <string name="runner_start">开始任务</string>
     <string name="runner_foreground_blocked">当前是前台模式，请先切换到后台模式</string>
+    <string name="runner_foreground_schedule_blocked">前台模式不会自动启动定时任务；如需到点自动执行，请切换到后台模式</string>
     <string name="runner_stop">停止</string>
     <string name="runner_stopping">停止中…</string>
 

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RunLauncherTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RunLauncherTest.kt
@@ -202,7 +202,8 @@ class RunLauncherTest {
         // 悬浮窗手动开跑是前台模式的正路
         assertEquals(RunLaunchResult.Started, launchIn(RunMode.FOREGROUND))
         assertEquals(RunLaunchResult.Started, launchIn(RunMode.BACKGROUND))
-        assertTrue(launchIn(RunMode.FOREGROUND, RunTrigger.Schedule("s1")) is RunLaunchResult.Blocked)
+        val blocked = launchIn(RunMode.FOREGROUND, RunTrigger.Schedule("s1")) as RunLaunchResult.Blocked
+        assertTrue(blocked.reason.isResource(R.string.runner_foreground_schedule_blocked))
     }
 
     /** 确认循环：先问，带着 token 重跑就该放行 */

--- a/app/src/test/java/com/aliothmoon/maafw/schedule/ScheduleViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/schedule/ScheduleViewModelTest.kt
@@ -1,0 +1,56 @@
+package com.aliothmoon.maafw.schedule
+
+import com.aliothmoon.maafw.config.InMemoryUserConfigurationStore
+import com.aliothmoon.maafw.domain.RunMode
+import com.aliothmoon.maafw.settings.FakeAppSettingsGateway
+import io.mockk.mockk
+import io.mockk.every
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScheduleViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val settings = FakeAppSettingsGateway()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `ui state follows the current run mode`() = runTest(dispatcher) {
+        settings.runMode.value = RunMode.FOREGROUND
+        val store = mockk<ScheduleStrategyStore>(relaxed = true) {
+            every { strategies } returns MutableStateFlow(emptyList())
+        }
+        val alarms = mockk<ScheduleAlarmManager>(relaxed = true) {
+            every { canScheduleExact() } returns true
+            every { hasExactAlarmToggle() } returns false
+        }
+        val viewModel = ScheduleViewModel(
+            store = store,
+            alarms = alarms,
+            triggerLog = mockk(relaxed = true),
+            configurationStore = InMemoryUserConfigurationStore(),
+            appSettings = settings,
+        )
+
+        check(viewModel.uiState.first { it.rows.isEmpty() }.runMode == RunMode.FOREGROUND)
+    }
+}


### PR DESCRIPTION
## 摘要
- 定时页状态订阅全局运行模式
- 前台模式下显示定时任务仅支持到点提醒的说明卡片
- 定时触发被前台模式拦截时，触发日志和错误日志输出明确的自动启动限制原因
- 补充 Schedule ViewModel 与前台定时拦截文案的单元测试

## 测试
- ./gradlew :app:testDebugUnitTest --tests com.aliothmoon.maafw.schedule.ScheduleViewModelTest
- ./gradlew :app:testDebugUnitTest --tests com.aliothmoon.maafw.runner.RunLauncherTest
- ./gradlew :app:lintDebug