### PR TITLE
feat: 支持重置任务列表参数

### DIFF
--- a/app/src/main/aidl/com/aliothmoon/maafw/RemoteService.aidl
+++ b/app/src/main/aidl/com/aliothmoon/maafw/RemoteService.aidl
@@ -138,4 +138,7 @@ interface RemoteService {
      * 走文件不回传字节：一张 720p PNG 几百 KB，binder 事务缓冲总共才 1MB
      */
     boolean saveCachedImage(String path) = 75;
+
+    /** 后台虚拟屏上的目标游戏帧率；未监控返回 -1 */
+    float getGameFps() = 76;
 }

--- a/app/src/main/java/com/aliothmoon/maafw/bridge/DriverClass.java
+++ b/app/src/main/java/com/aliothmoon/maafw/bridge/DriverClass.java
@@ -4,6 +4,7 @@ package com.aliothmoon.maafw.bridge;
 import android.content.pm.PackageInfo;
 
 import com.aliothmoon.maafw.remote.internal.ActivityUtils;
+import com.aliothmoon.maafw.remote.internal.GameFpsMonitor;
 import com.aliothmoon.maafw.remote.internal.PrimaryDisplayManager;
 import com.aliothmoon.maafw.third.FakeContext;
 import com.aliothmoon.maafw.third.Ln;
@@ -30,12 +31,12 @@ public final class DriverClass {
         if (displayId == PrimaryDisplayManager.DISPLAY_ID) {
             return ActivityUtils.startApp(packageName, displayId, forceStop);
         }
+        String target = ActivityUtils.packageNameOf(packageName);
         boolean ret = ActivityUtils.startApp(packageName, displayId, forceStop, true);
         if (ret) {
             // 部分 ROM（如 One UI）会把游戏从虚拟屏挪回主屏，启动后校验并尝试拉回；
             // 拉不回则快速失败，避免识别对着虚拟屏空转
             // 这里比对的是包名，PI 给的可能是 "包名/Activity"，先拆
-            String target = ActivityUtils.packageNameOf(packageName);
             ret = ActivityUtils.ensureAppOnDisplay(target, displayId);
             if (!ret) {
                 Ln.e(TAG + ": " + target + " could not be pinned on display " + displayId);
@@ -43,6 +44,7 @@ public final class DriverClass {
         }
         if (ret) {
             awaitFirstFrame();
+            GameFpsMonitor.start(target);
         }
         return ret;
     }

--- a/app/src/main/java/com/aliothmoon/maafw/config/ConfigurationResolver.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/config/ConfigurationResolver.kt
@@ -128,6 +128,30 @@ object ConfigurationResolver {
 
     fun newConfigurationId(): RunConfigurationId = RunConfigurationId(UUID.randomUUID().toString())
 
+    /**
+     * 重置任务参数但不改变列表身份。preset 只在任务名序列唯一对应时用于恢复勾选状态，
+     * 参数始终回落到 interface option 自己的默认值。
+     */
+    fun resetTaskList(
+        definition: ProjectDefinition,
+        configuration: RunConfiguration,
+    ): RunConfiguration {
+        val taskNames = configuration.tasks.map { it.taskName }
+        val templateTasks = definition.templates
+            .map { it.distinctTasks }
+            .filter { it.map { templateTask -> templateTask.taskName } == taskNames }
+            .singleOrNull()
+
+        return configuration.copy(
+            tasks = configuration.tasks.mapIndexed { index, task ->
+                task.copy(
+                    enabled = templateTasks?.getOrNull(index)?.enabled ?: task.enabled,
+                    optionValues = emptyMap(),
+                )
+            },
+        )
+    }
+
     private fun resolveConfiguration(
         definition: ProjectDefinition,
         runConfiguration: RunConfiguration,

--- a/app/src/main/java/com/aliothmoon/maafw/di/RunnerModule.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/di/RunnerModule.kt
@@ -8,6 +8,9 @@ import com.aliothmoon.maafw.runner.CloseTargetAppHook
 import com.aliothmoon.maafw.runner.CountdownHook
 import com.aliothmoon.maafw.runner.FocusContentResolver
 import com.aliothmoon.maafw.runner.FocusDispatcher
+import com.aliothmoon.maafw.runner.GameFpsHook
+import com.aliothmoon.maafw.runner.GameFpsWatcher
+import com.aliothmoon.maafw.runner.RemoteGameFpsReader
 import com.aliothmoon.maafw.telemetry.TelemetryController
 import com.aliothmoon.maafw.runner.ForegroundModePrecheck
 import com.aliothmoon.maafw.runner.KeepAliveHook
@@ -92,6 +95,14 @@ val runnerModule = module {
     }
     single<RunJournal> { get<RunLogRecorder>() }
 
+    single {
+        GameFpsWatcher(
+            reader = RemoteGameFpsReader(get()),
+            journal = get(),
+            scope = get(named<AppCoroutineScope>()),
+        )
+    }
+
     single<PreviewPort> {
         RemotePreviewPort(
             scope = get(named<AppCoroutineScope>()),
@@ -125,6 +136,7 @@ val runnerModule = module {
                 CloseTargetAppHook(get(), get<AppSettingsManager>()),
                 CountdownHook,
                 KeepAliveHook(get()),
+                GameFpsHook(get()),
                 WatchdogNoticeHook(
                     watchdogState = get<PermissionGateway>().watchdogState,
                     servicePort = get(),

--- a/app/src/main/java/com/aliothmoon/maafw/remote/RemoteServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/RemoteServiceImpl.kt
@@ -10,6 +10,7 @@ import com.aliothmoon.maafw.constant.DisplayMode
 import com.aliothmoon.maafw.maa.MaaFrameworkLoader
 import com.aliothmoon.maafw.remote.internal.ActivityUtils
 import com.aliothmoon.maafw.remote.internal.AppWatchdog
+import com.aliothmoon.maafw.remote.internal.GameFpsMonitor
 import com.aliothmoon.maafw.remote.internal.PermissionGrantHelper
 import com.aliothmoon.maafw.service.AccessibilityHelperService
 import com.aliothmoon.maafw.remote.internal.PowerController
@@ -150,6 +151,7 @@ class RemoteServiceImpl : RemoteService.Stub() {
 
     override fun setVirtualDisplayMode(mode: Int): Boolean = when (mode) {
         DisplayMode.PRIMARY -> {
+            GameFpsMonitor.stop()
             VirtualDisplayManager.stop()
             virtualDisplayMode.set(mode)
             true
@@ -181,6 +183,7 @@ class RemoteServiceImpl : RemoteService.Stub() {
 
     override fun stopVirtualDisplay() {
         AppWatchdog.stopWatching()
+        GameFpsMonitor.stop()
         when (virtualDisplayMode.get()) {
             DisplayMode.PRIMARY -> PrimaryDisplayManager.stop()
             DisplayMode.BACKGROUND -> {
@@ -194,7 +197,9 @@ class RemoteServiceImpl : RemoteService.Stub() {
     override fun isAppOnVirtualDisplay(packageName: String): Boolean {
         val displayId = VirtualDisplayManager.getDisplayId()
         if (displayId == DefaultDisplayConfig.DISPLAY_NONE) return true
-        return ActivityUtils.isAppOnDisplay(packageName, displayId)
+        return ActivityUtils.isAppOnDisplay(packageName, displayId).also { onDisplay ->
+            if (onDisplay) GameFpsMonitor.ensureStarted(packageName)
+        }
     }
 
     override fun moveAppToVirtualDisplay(packageName: String): Boolean {
@@ -284,6 +289,8 @@ class RemoteServiceImpl : RemoteService.Stub() {
     override fun saveCachedImage(path: String?): Boolean =
         !path.isNullOrBlank() && runner.saveCachedImage(path)
 
+    override fun getGameFps(): Float = GameFpsMonitor.currentFps()
+
     override fun maaVersion(): String? = MaaFrameworkLoader.library?.MaaVersion()
 
     /**
@@ -344,6 +351,7 @@ class RemoteServiceImpl : RemoteService.Stub() {
      * 它自己按 flag 文件判要不要动手，没改过时是空操作
      */
     private fun cleanup() {
+        step("game fps") { GameFpsMonitor.stop() }
         step("screen size") { ScreenManager.destroy() }
         step("power") { PowerController.destroy() }
         step("primary display") { PrimaryDisplayManager.stop() }

--- a/app/src/main/java/com/aliothmoon/maafw/remote/internal/ActivityUtils.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/internal/ActivityUtils.kt
@@ -85,6 +85,14 @@ object ActivityUtils {
     @JvmStatic
     fun packageNameOf(spec: String): String = componentOf(spec)?.packageName ?: spec
 
+    /** Android 13+ task FPS callback 只认 taskId；找不到则由调用方走帧计数回退 */
+    @JvmStatic
+    fun findTaskId(packageName: String): Int? {
+        val task = runCatching { findRecentTask(packageName) }.getOrNull() ?: return null
+        @Suppress("DEPRECATION")
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) task.taskId else task.id
+    }
+
     private fun componentOf(spec: String): ComponentName? =
         spec.takeIf { it.contains('/') }?.let { ComponentName.unflattenFromString(it) }
 
@@ -243,12 +251,10 @@ object ActivityUtils {
     }
 
     private fun moveAppTaskToDisplay(packageName: String, displayId: Int): Boolean {
-        val task = runCatching { findRecentTask(packageName) }.getOrNull() ?: run {
+        val taskId = findTaskId(packageName) ?: run {
             Ln.w("moveAppTaskToDisplay: no running task of $packageName")
             return false
         }
-        @Suppress("DEPRECATION")
-        val taskId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) task.taskId else task.id
         moveTaskToDisplayMethod?.let { method ->
             runCatching {
                 method.invoke(activityTaskManager, taskId, displayId)

--- a/app/src/main/java/com/aliothmoon/maafw/remote/internal/FrameCountFpsEstimator.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/internal/FrameCountFpsEstimator.kt
@@ -1,0 +1,23 @@
+package com.aliothmoon.maafw.remote.internal
+
+/**
+ * 由单调递增的帧计数与纳秒时间戳估算区间帧率；纯逻辑，便于单测
+ */
+class FrameCountFpsEstimator {
+
+    private var lastCount = -1L
+    private var lastNs = 0L
+
+    /** 首个样本、计数回绕（截图器重建）或时间未前进时返回 null */
+    fun sample(frameCount: Long, nowNs: Long): Float? {
+        val valid = lastCount >= 0 && frameCount >= lastCount && nowNs > lastNs
+        val fps = if (valid) {
+            (frameCount - lastCount) * 1_000_000_000f / (nowNs - lastNs)
+        } else {
+            null
+        }
+        lastCount = frameCount
+        lastNs = nowNs
+        return fps
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/remote/internal/GameFpsMonitor.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/internal/GameFpsMonitor.kt
@@ -1,0 +1,175 @@
+package com.aliothmoon.maafw.remote.internal
+
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.os.Parcel
+import android.os.SystemClock
+import com.aliothmoon.maafw.bridge.NativeBridgeLib
+import com.aliothmoon.maafw.third.Ln
+import com.aliothmoon.maafw.third.wrappers.ServiceManager
+import java.lang.reflect.Proxy
+import kotlin.concurrent.thread
+
+/**
+ * 后台虚拟屏上的目标游戏实时帧率
+ *
+ * Android 13+ 优先用 SurfaceFlinger 的 task present-to-present FPS；旧系统或注册失败时，
+ * 按 libbridge 收到的合成帧计数做差。虚拟屏预览上只有目标游戏，两种口径都可用。
+ */
+object GameFpsMonitor {
+
+    private const val TAG = "GameFpsMonitor"
+    const val UNKNOWN = -1f
+
+    /** SurfaceFlinger 只在合成时派发；静止画面超过该时长视为 0 FPS */
+    private const val TASK_FPS_STALE_MS = 2_000L
+    private const val FRAME_COUNT_INTERVAL_MS = 1_000L
+
+    @Volatile
+    private var source: Source? = null
+
+    @JvmStatic
+    @Synchronized
+    fun start(packageName: String) {
+        stop()
+        val next = createTaskSource(packageName)?.takeIf { it.start() }
+            ?: FrameCountSource().also { it.start() }
+        source = next
+        Ln.i("$TAG: start ${next.name} for $packageName")
+    }
+
+    /** 游戏不是由框架拉起时，看门狗确认它在虚拟屏上后从这里补启动 */
+    @JvmStatic
+    @Synchronized
+    fun ensureStarted(packageName: String) {
+        if (source == null) start(packageName)
+    }
+
+    @JvmStatic
+    @Synchronized
+    fun stop() {
+        source?.let {
+            it.stop()
+            Ln.i("$TAG: stop ${it.name}")
+        }
+        source = null
+    }
+
+    @JvmStatic
+    fun currentFps(): Float = source?.currentFps() ?: UNKNOWN
+
+    private fun createTaskSource(packageName: String): TaskFpsSource? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
+        val taskId = ActivityUtils.findTaskId(packageName) ?: run {
+            Ln.w("$TAG: no task for $packageName, fall back to frame count")
+            return null
+        }
+        return TaskFpsSource(taskId)
+    }
+
+    private interface Source {
+        val name: String
+
+        /** 失败返回 false，调用方换下一种来源 */
+        fun start(): Boolean
+        fun stop()
+        fun currentFps(): Float
+    }
+
+    /** ITaskFpsCallback 只有一个 oneway onFpsReported(float)，手工 Binder 比引入隐藏类副本轻 */
+    private class TaskFpsSource(private val taskId: Int) : Source {
+
+        override val name = "TaskFps(task=$taskId)"
+
+        @Volatile
+        private var fps = 0f
+
+        @Volatile
+        private var lastReportMs = 0L
+
+        private val binder = object : Binder() {
+            init {
+                attachInterface(null, DESCRIPTOR)
+            }
+
+            override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+                if (code != TRANSACTION_ON_FPS_REPORTED) return super.onTransact(code, data, reply, flags)
+                data.enforceInterface(DESCRIPTOR)
+                fps = data.readFloat()
+                lastReportMs = SystemClock.elapsedRealtime()
+                return true
+            }
+        }
+
+        private val callback: Any? = runCatching {
+            val iface = Class.forName("android.window.ITaskFpsCallback")
+            Proxy.newProxyInstance(iface.classLoader, arrayOf(iface)) { proxy, method, args ->
+                when (method.name) {
+                    "asBinder" -> binder
+                    "hashCode" -> System.identityHashCode(proxy)
+                    "equals" -> proxy === args[0]
+                    "toString" -> name
+                    else -> null
+                }
+            }
+        }.getOrNull()
+
+        override fun start(): Boolean {
+            val cb = callback ?: return false
+            val ok = ServiceManager.getWindowManager().registerTaskFpsCallback(taskId, cb)
+            if (ok) lastReportMs = SystemClock.elapsedRealtime()
+            else Ln.w("$TAG: registerTaskFpsCallback failed, fall back to frame count")
+            return ok
+        }
+
+        override fun stop() {
+            callback?.let { ServiceManager.getWindowManager().unregisterTaskFpsCallback(it) }
+        }
+
+        override fun currentFps(): Float =
+            if (SystemClock.elapsedRealtime() - lastReportMs > TASK_FPS_STALE_MS) 0f else fps
+
+        private companion object {
+            const val DESCRIPTOR = "android.window.ITaskFpsCallback"
+            const val TRANSACTION_ON_FPS_REPORTED = IBinder.FIRST_CALL_TRANSACTION
+        }
+    }
+
+    private class FrameCountSource : Source {
+
+        override val name = "FrameCount"
+
+        @Volatile
+        private var fps = 0f
+
+        @Volatile
+        private var running = false
+        private var worker: Thread? = null
+
+        override fun start(): Boolean {
+            running = true
+            worker = thread(name = "game-fps-sampler", isDaemon = true) {
+                val estimator = FrameCountFpsEstimator()
+                estimator.sample(NativeBridgeLib.getFrameCount(), System.nanoTime())
+                while (running) {
+                    try {
+                        Thread.sleep(FRAME_COUNT_INTERVAL_MS)
+                    } catch (_: InterruptedException) {
+                        break
+                    }
+                    estimator.sample(NativeBridgeLib.getFrameCount(), System.nanoTime())?.let { fps = it }
+                }
+            }
+            return true
+        }
+
+        override fun stop() {
+            running = false
+            worker?.interrupt()
+            worker = null
+        }
+
+        override fun currentFps(): Float = fps
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/runner/EnvironmentHooks.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/EnvironmentHooks.kt
@@ -59,6 +59,9 @@ internal object HookOrder {
 
     /** 只是挂一个监听，排在最后，收尾时最先摘掉 */
     const val WATCHDOG_NOTICE = 50
+
+    /** 同为观察者，排在看门狗之后；收尾时先停 FPS 轮询，再看门狗 */
+    const val GAME_FPS = 55
 }
 
 /**

--- a/app/src/main/java/com/aliothmoon/maafw/runner/GameFpsAdvisor.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/GameFpsAdvisor.kt
@@ -1,0 +1,73 @@
+package com.aliothmoon.maafw.runner
+
+import kotlin.math.ceil
+
+/**
+ * 低帧率判定：最近 [windowSize] 个有效样本里低于阈值的占比达到 [minFraction] 才告警
+ *
+ * 用占比而不是均值，转场或加载时的短暂深谷不该触发；每档每次运行只提示一次
+ */
+class GameFpsAdvisor(
+    private val windowSize: Int = DEFAULT_WINDOW_SIZE,
+    private val lowThreshold: Float = LOW_FPS,
+    private val degradedThreshold: Float = DEGRADED_FPS,
+    minFraction: Float = DEFAULT_MIN_FRACTION,
+    private val maxIdleStreak: Int = DEFAULT_MAX_IDLE_STREAK,
+) {
+
+    enum class Level { LOW, DEGRADED }
+
+    /** [medianFps] 是触发时窗口中位数，不是当次瞬时值 */
+    data class Advice(val level: Level, val medianFps: Float)
+
+    private val requiredCount = ceil(windowSize * minFraction).toInt().coerceIn(1, windowSize)
+    private val window = ArrayDeque<Float>()
+    private var idleStreak = 0
+    private var lowAdvised = false
+    private var degradedAdvised = false
+
+    fun onSample(fps: Float): Advice? {
+        if (fps <= 0f) {
+            if (++idleStreak > maxIdleStreak) window.clear()
+            return null
+        }
+        idleStreak = 0
+        window.addLast(fps)
+        while (window.size > windowSize) window.removeFirst()
+        if (window.size < windowSize) return null
+
+        return when {
+            window.count { it < lowThreshold } >= requiredCount ->
+                advise(Level.LOW, lowAdvised).also { lowAdvised = true }
+
+            window.count { it < degradedThreshold } >= requiredCount ->
+                advise(Level.DEGRADED, degradedAdvised).also { degradedAdvised = true }
+
+            else -> null
+        }
+    }
+
+    private fun advise(level: Level, alreadyAdvised: Boolean): Advice? =
+        if (alreadyAdvised) null else Advice(level, median())
+
+    private fun median(): Float {
+        val sorted = window.sorted()
+        val mid = sorted.size / 2
+        return if (sorted.size % 2 == 0) (sorted[mid - 1] + sorted[mid]) / 2f else sorted[mid]
+    }
+
+    fun reset() {
+        window.clear()
+        idleStreak = 0
+        lowAdvised = false
+        degradedAdvised = false
+    }
+
+    companion object {
+        const val DEFAULT_WINDOW_SIZE = 15
+        const val DEFAULT_MIN_FRACTION = 0.8f
+        const val DEFAULT_MAX_IDLE_STREAK = 3
+        const val LOW_FPS = 30f
+        const val DEGRADED_FPS = 50f
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/runner/GameFpsHook.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/GameFpsHook.kt
@@ -1,0 +1,18 @@
+package com.aliothmoon.maafw.runner
+
+import com.aliothmoon.maafw.domain.RunMode
+
+/** 后台运行期的观察者：只采样与写日志，失败不参与运行成败判定 */
+class GameFpsHook(private val watcher: GameFpsWatcher) : RunEnvHook {
+
+    override val id: String = "game-fps"
+    override val anchor: Anchor = Anchor.AfterAccepted
+    override val order: Int = HookOrder.GAME_FPS
+    override val gating: Boolean = false
+
+    override suspend fun engage(ctx: RunContext): EngageResult {
+        if (ctx.runMode != RunMode.BACKGROUND) return EngageResult.Skipped()
+        watcher.start()
+        return EngageResult.Engaged(Release { watcher.stop() })
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/runner/GameFpsWatcher.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/GameFpsWatcher.kt
@@ -1,0 +1,80 @@
+package com.aliothmoon.maafw.runner
+
+import com.aliothmoon.maafw.MaaDispatchers
+import com.aliothmoon.maafw.R
+import com.aliothmoon.maafw.i18n.uiTextOf
+import com.aliothmoon.maafw.privileged.PrivilegedServicePort
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
+
+interface GameFpsReader {
+    /** null = 远端未监控或无法读取 */
+    suspend fun readGameFps(): Float?
+}
+
+class RemoteGameFpsReader(private val servicePort: PrivilegedServicePort) : GameFpsReader {
+    override suspend fun readGameFps(): Float? = withContext(MaaDispatchers.IO) {
+        runCatching { servicePort.serviceOrNull()?.getGameFps() }
+            .getOrNull()
+            ?.takeIf { it >= 0f }
+    }
+}
+
+/** 后台运行期轮询游戏帧率：供预览显示，并在持续低帧率时写运行日志 */
+class GameFpsWatcher(
+    private val reader: GameFpsReader,
+    private val journal: RunJournal,
+    private val scope: CoroutineScope,
+) {
+
+    private val advisor = GameFpsAdvisor()
+    private val _fps = MutableStateFlow<Float?>(null)
+    val fps: StateFlow<Float?> = _fps.asStateFlow()
+    private var job: Job? = null
+
+    @Synchronized
+    fun start() {
+        stop()
+        advisor.reset()
+        job = scope.launch {
+            while (isActive) {
+                delay(POLL_INTERVAL_MS)
+                pollOnce()
+            }
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        job?.cancel()
+        job = null
+        _fps.value = null
+    }
+
+    internal suspend fun pollOnce() {
+        val value = reader.readGameFps()
+        _fps.value = value
+        advisor.onSample(value ?: 0f)?.let { advice ->
+            val fps = advice.medianFps.roundToInt()
+            when (advice.level) {
+                GameFpsAdvisor.Level.LOW ->
+                    journal.note(RunNote.Error, uiTextOf(R.string.run_log_game_fps_low, fps))
+
+                GameFpsAdvisor.Level.DEGRADED ->
+                    journal.note(RunNote.Warning, uiTextOf(R.string.run_log_game_fps_degraded, fps))
+            }
+        }
+    }
+
+    private companion object {
+        const val POLL_INTERVAL_MS = 1_000L
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
@@ -222,6 +222,9 @@ sealed interface SessionIntent {
         val value: OptionValue,
     ) : SessionIntent
 
+    /** 清任务参数；任务序列唯一匹配 preset 时才连带恢复勾选状态 */
+    data class ResetTaskList(val configurationId: RunConfigurationId) : SessionIntent
+
     /** 不属于任何运行配置：改一次对所有配置的所有任务生效 */
     data class SetGlobalOption(val optionName: String, val value: OptionValue) : SessionIntent
 

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -418,6 +418,14 @@ class SessionViewModel(
                 }
             }
 
+            is SessionIntent.ResetTaskList -> guarded {
+                val definition = (projectRepository.state.value as? ProjectState.Ready)?.definition
+                if (definition == null) return@guarded
+                mutateConfiguration(intent.configurationId) { configuration ->
+                    ConfigurationResolver.resetTaskList(definition, configuration)
+                }
+            }
+
             is SessionIntent.SetGlobalOption -> guarded {
                 configurationStore.update {
                     it.copy(globalOptionValues = it.globalOptionValues + (intent.optionName to intent.value))

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -32,6 +32,7 @@ import com.aliothmoon.maafw.domain.ResolvedProjectSession
 import com.aliothmoon.maafw.runner.FocusChannel
 import com.aliothmoon.maafw.runner.FocusDispatcher
 import com.aliothmoon.maafw.runner.FocusMessage
+import com.aliothmoon.maafw.runner.GameFpsWatcher
 import com.aliothmoon.maafw.runner.PreviewPort
 import com.aliothmoon.maafw.runner.PreviewTouchMarker
 import com.aliothmoon.maafw.runner.RunLogEntry
@@ -117,6 +118,8 @@ class SessionViewModel(
     private val focusDispatcher: FocusDispatcher,
     /** 运行日志的产地；VM 只转发它的流并转达「清空」 */
     private val recorder: RunLogRecorder,
+    /** 后台运行期的实时 FPS；单独转发，不并入聚合 UI 状态 */
+    private val gameFpsWatcher: GameFpsWatcher,
     private val piInstall: PiInstallCoordinator,
 ) : ViewModel() {
 
@@ -175,6 +178,9 @@ class SessionViewModel(
      * 一次滑动能连发几十个触点，混进聚合态会让整棵树按触摸频率重组
      */
     val previewMarkers: StateFlow<List<PreviewTouchMarker>> = previewPort.markers
+
+    /** FPS 每秒更新，独立成流避免整棵 UI 树跟着重组 */
+    val gameFps: StateFlow<Float?> = gameFpsWatcher.fps
 
     /**
      * 运行日志，同样单独一条流：一次长跑上千条，混进聚合态会让整棵树按日志频率重组

--- a/app/src/main/java/com/aliothmoon/maafw/third/wrappers/WindowManager.java
+++ b/app/src/main/java/com/aliothmoon/maafw/third/wrappers/WindowManager.java
@@ -37,6 +37,11 @@ public final class WindowManager {
 
     private Method syncInputTransactions;
 
+    private static final String TASK_FPS_CALLBACK_CLASS = "android.window.ITaskFpsCallback";
+
+    private Method registerTaskFpsCallbackMethod;
+    private Method unregisterTaskFpsCallbackMethod;
+
     static WindowManager create() {
         IInterface manager = ServiceManager.getService("window", "android.view.IWindowManager");
         return new WindowManager(manager);
@@ -133,6 +138,45 @@ public final class WindowManager {
             clearForcedDisplaySizeMethod = manager.getClass().getMethod("clearForcedDisplaySize", int.class);
         }
         return clearForcedDisplaySizeMethod;
+    }
+
+    private Method getRegisterTaskFpsCallbackMethod() throws ReflectiveOperationException {
+        if (registerTaskFpsCallbackMethod == null) {
+            Class<?> callbackClass = Class.forName(TASK_FPS_CALLBACK_CLASS);
+            registerTaskFpsCallbackMethod = manager.getClass()
+                    .getMethod("registerTaskFpsCallback", int.class, callbackClass);
+        }
+        return registerTaskFpsCallbackMethod;
+    }
+
+    private Method getUnregisterTaskFpsCallbackMethod() throws ReflectiveOperationException {
+        if (unregisterTaskFpsCallbackMethod == null) {
+            Class<?> callbackClass = Class.forName(TASK_FPS_CALLBACK_CLASS);
+            unregisterTaskFpsCallbackMethod = manager.getClass()
+                    .getMethod("unregisterTaskFpsCallback", callbackClass);
+        }
+        return unregisterTaskFpsCallbackMethod;
+    }
+
+    /** Android 13+；callback 需实现框架侧 ITaskFpsCallback，调用方持有 ACCESS_FPS_COUNTER */
+    public boolean registerTaskFpsCallback(int taskId, Object callback) {
+        try {
+            getRegisterTaskFpsCallbackMethod().invoke(manager, taskId, callback);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
+            return false;
+        }
+    }
+
+    public boolean unregisterTaskFpsCallback(Object callback) {
+        try {
+            getUnregisterTaskFpsCallbackMethod().invoke(manager, callback);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
+            return false;
+        }
     }
 
 

--- a/app/src/main/java/com/aliothmoon/maafw/ui/AppRoot.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/AppRoot.kt
@@ -187,6 +187,7 @@ fun AppRoot(
     // 刻意不用 by 解构：在这一层读就等于让整棵树跟着触摸与日志频率重组，
     // 往下传取值函数，读推迟到真正显示它们的叶子
     val previewMarkersState = viewModel.previewMarkers.collectAsStateWithLifecycle()
+    val gameFpsState = viewModel.gameFps.collectAsStateWithLifecycle()
     val runLogState = viewModel.runLog.collectAsStateWithLifecycle()
 
     // 语言重载唯一触发点：App/系统切语言都经 Activity 重建后到此
@@ -214,6 +215,7 @@ fun AppRoot(
         rememberMovablePreview(
             resolution = resolution,
             markers = { previewMarkersState.value },
+            fps = { gameFpsState.value },
             // 不等 setFixedSize 那一轮：搬一次家要 50ms+ 才对上尺寸，期间遮罩会盖住刚回来的画面
             onSurfaceCreated = { previewSurfaceReady = true },
             onSurfaceAvailable = {

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksPreviewSection.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksPreviewSection.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -67,6 +68,7 @@ import com.aliothmoon.maafw.ui.components.MaaPreviewSurface
 import com.aliothmoon.maafw.ui.components.MaaTouchOverlay
 import com.aliothmoon.maafw.ui.components.maaClickable
 import com.aliothmoon.maafw.ui.pip.LocalIsInPip
+import kotlin.math.roundToInt
 
 /**
  * 预览面做成 movableContent：在内嵌卡片与全屏宿主之间搬家时复用同一份组合状态
@@ -82,12 +84,14 @@ internal fun rememberMovablePreview(
     resolution: DisplayResolution,
     /** 传取值而不是值：一次滑动几十个触点，在 AppRoot 那层读会把整棵树按触摸频率重组 */
     markers: () -> List<PreviewTouchMarker>,
+    fps: () -> Float?,
     onSurfaceCreated: () -> Unit,
     onSurfaceAvailable: (PlatformSurface) -> Unit,
     onSurfaceDestroyed: () -> Unit,
 ): @Composable () -> Unit {
     val currentResolution by rememberUpdatedState(resolution)
     val currentMarkers by rememberUpdatedState(markers)
+    val currentFps by rememberUpdatedState(fps)
     val currentCreated by rememberUpdatedState(onSurfaceCreated)
     val currentAvailable by rememberUpdatedState(onSurfaceAvailable)
     val currentDestroyed by rememberUpdatedState(onSurfaceDestroyed)
@@ -117,6 +121,22 @@ internal fun rememberMovablePreview(
                         resolution = currentResolution,
                         modifier = Modifier.fillMaxSize(),
                     )
+                }
+                currentFps()?.let { value ->
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.TopStart,
+                    ) {
+                        Text(
+                            text = "${value.roundToInt()} FPS",
+                            color = Color.White.copy(alpha = 0.85f),
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier
+                                .padding(6.dp)
+                                .background(Color.Black.copy(alpha = 0.35f), RoundedCornerShape(4.dp))
+                                .padding(horizontal = 5.dp, vertical = 2.dp),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksRunnerBar.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksRunnerBar.kt
@@ -219,12 +219,15 @@ internal fun TasksQuickOptionsPanel(
                 }
                 ActionTile(
                     icon = Icons.Outlined.Refresh,
-                    label = stringResource(R.string.settings_reload_project),
+                    label = stringResource(R.string.quick_action_reset_task_list),
                     accent = MaterialTheme.colorScheme.secondary,
-                    enabled = !state.configurationLocked,
+                    enabled = !state.configurationLocked && state.activeConfiguration != null,
                     onClick = {
-                        onDismiss()
-                        onIntent(SessionIntent.ReloadProject)
+                        val configurationId = state.activeConfiguration?.id
+                        if (configurationId != null) {
+                            onDismiss()
+                            onIntent(SessionIntent.ResetTaskList(configurationId))
+                        }
                     },
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -390,6 +390,7 @@
     <string name="runner_quick_options">Options</string>
     <string name="quick_actions_title">Quick actions</string>
     <string name="quick_settings_title">Automation</string>
+    <string name="quick_action_reset_task_list">Reset task list</string>
     <string name="quick_action_screen_saver">Screen off</string>
     <string name="quick_action_close_app">Close target app</string>
     <string name="quick_setting_close_app_after_task">Close the target app when task ends</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -470,6 +470,8 @@
     <string name="run_log_app_process_gone">The target app process is not running or was closed unexpectedly (%1$s).</string>
     <string name="run_log_app_unknown">unknown app</string>
     <string name="run_log_agent_flood_recovered">Agent output is back to normal</string>
+    <string name="run_log_game_fps_low">The game is running at only %1$d FPS, below 30; automation may fail. Enable high frame rate mode in the game and disable power saving mode</string>
+    <string name="run_log_game_fps_degraded">The game is running at %1$d FPS, below 50; battle timing may drift. Enable high frame rate mode in the game and disable power saving mode</string>
 
     <!-- Run history: one file per run -->
     <string name="log_archive_title">Run history</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,6 +462,8 @@
     <string name="run_log_app_process_gone">目标应用进程未启动或被异常关闭(%1$s)</string>
     <string name="run_log_app_unknown">未知应用</string>
     <string name="run_log_agent_flood_recovered">Agent 输出已恢复正常</string>
+    <string name="run_log_game_fps_low">游戏画面帧率仅 %1$d FPS，低于 30，自动战斗可能出错；请在游戏设置中开启高帧率模式，并关闭省电模式</string>
+    <string name="run_log_game_fps_degraded">游戏画面帧率 %1$d FPS，低于 50，战斗时机可能不准；建议在游戏设置中开启高帧率模式，并关闭省电模式</string>
 
     <!-- 历史日志：每轮运行落盘一份 -->
     <string name="log_archive_title">运行历史</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -383,6 +383,7 @@
     <string name="runner_quick_options">快捷选项</string>
     <string name="quick_actions_title">快捷操作</string>
     <string name="quick_settings_title">自动设置</string>
+    <string name="quick_action_reset_task_list">重置任务列表</string>
     <string name="quick_action_screen_saver">熄屏挂机</string>
     <string name="quick_action_close_app">关闭目标应用</string>
     <string name="quick_setting_close_app_after_task">任务自动结束时关闭目标应用</string>

--- a/app/src/test/java/com/aliothmoon/maafw/config/ConfigurationResolverTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/config/ConfigurationResolverTest.kt
@@ -113,6 +113,116 @@ class ConfigurationResolverTest {
     }
 
     @Test
+    fun `reset task list clears values and restores unique preset checks`() {
+        val def = definition(
+            templates = listOf(
+                ConfigurationTemplate(
+                    name = "P",
+                    label = "模板",
+                    description = null,
+                    tasks = listOf(
+                        TemplateTask("T1", enabled = false, optionValues = emptyMap()),
+                        TemplateTask("T2", enabled = true, optionValues = emptyMap()),
+                    ),
+                ),
+            ),
+        )
+        val configuration = RunConfiguration(
+            id = RunConfigurationId("c1"),
+            name = "日常",
+            tasks = listOf(
+                ConfiguredTask(
+                    taskName = "T1",
+                    enabled = true,
+                    optionValues = mapOf("option" to OptionValue.Inputs(mapOf("count" to "2"))),
+                    customLabel = "别名",
+                    instanceId = "i1",
+                ),
+                ConfiguredTask(
+                    taskName = "T2",
+                    enabled = false,
+                    optionValues = mapOf("option" to OptionValue.SingleCase("a")),
+                    instanceId = "i2",
+                ),
+            ),
+        )
+
+        val result = ConfigurationResolver.resetTaskList(def, configuration)
+
+        assertEquals(listOf(false, true), result.tasks.map { it.enabled })
+        assertTrue(result.tasks.all { it.optionValues.isEmpty() })
+        assertEquals("别名", result.tasks[0].customLabel)
+        assertEquals(listOf("i1", "i2"), result.tasks.map { it.instanceId })
+    }
+
+    @Test
+    fun `reset task list keeps checks when task sequence differs from preset`() {
+        val def = definition(
+            templates = listOf(
+                ConfigurationTemplate(
+                    name = "P",
+                    label = "模板",
+                    description = null,
+                    tasks = listOf(
+                        TemplateTask("T1", enabled = false, optionValues = emptyMap()),
+                        TemplateTask("T2", enabled = true, optionValues = emptyMap()),
+                    ),
+                ),
+            ),
+        )
+        val configuration = RunConfiguration(
+            id = RunConfigurationId("c1"),
+            name = "日常",
+            tasks = listOf(
+                ConfiguredTask(
+                    taskName = "T2",
+                    enabled = true,
+                    optionValues = mapOf("option" to OptionValue.SingleCase("a")),
+                    instanceId = "i1",
+                ),
+                ConfiguredTask(
+                    taskName = "T1",
+                    enabled = true,
+                    optionValues = mapOf("option" to OptionValue.SingleCase("b")),
+                    instanceId = "i2",
+                ),
+            ),
+        )
+
+        val result = ConfigurationResolver.resetTaskList(def, configuration)
+
+        assertEquals(listOf(true, true), result.tasks.map { it.enabled })
+        assertTrue(result.tasks.all { it.optionValues.isEmpty() })
+    }
+
+    @Test
+    fun `reset task list keeps checks when multiple presets match task sequence`() {
+        val template = ConfigurationTemplate(
+            name = "P",
+            label = "模板",
+            description = null,
+            tasks = listOf(
+                TemplateTask("T1", enabled = false, optionValues = emptyMap()),
+                TemplateTask("T2", enabled = true, optionValues = emptyMap()),
+            ),
+        )
+        val def = definition(templates = listOf(template, template.copy(name = "P2", label = "模板2")))
+        val configuration = RunConfiguration(
+            id = RunConfigurationId("c1"),
+            name = "日常",
+            tasks = listOf(
+                ConfiguredTask("T1", enabled = true, mapOf("option" to OptionValue.SingleCase("a")), instanceId = "i1"),
+                ConfiguredTask("T2", enabled = false, mapOf("option" to OptionValue.SingleCase("b")), instanceId = "i2"),
+            ),
+        )
+
+        val result = ConfigurationResolver.resetTaskList(def, configuration)
+
+        assertEquals(listOf(true, false), result.tasks.map { it.enabled })
+        assertTrue(result.tasks.all { it.optionValues.isEmpty() })
+    }
+
+    @Test
     fun `resource selection falls back with warning when missing`() {
         val session = ConfigurationResolver.resolve(
             definition(),

--- a/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
@@ -24,6 +24,7 @@ open class FakePrivilegedService : RemoteService {
     var unlockResult: Int = WakeUnlockResult.OK
     var lockAndSleepResult: Int = WakeUnlockResult.OK
     var screenOn: Boolean = true
+    var currentGameFps: Float = -1f
 
     var unlockCalls: MutableList<String> = mutableListOf()
         private set
@@ -60,6 +61,8 @@ open class FakePrivilegedService : RemoteService {
     }
 
     override fun isScreenOn(): Boolean = screenOn
+
+    override fun getGameFps(): Float = currentGameFps
 
     // ── 其余：本测试用不到，保持无副作用的零值 ──
 

--- a/app/src/test/java/com/aliothmoon/maafw/remote/internal/FrameCountFpsEstimatorTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/remote/internal/FrameCountFpsEstimatorTest.kt
@@ -1,0 +1,40 @@
+package com.aliothmoon.maafw.remote.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FrameCountFpsEstimatorTest {
+
+    @Test
+    fun `the first sample only establishes a baseline`() {
+        val estimator = FrameCountFpsEstimator()
+
+        assertNull(estimator.sample(frameCount = 10, nowNs = 1_000_000_000))
+    }
+
+    @Test
+    fun `fps comes from the count delta`() {
+        val estimator = FrameCountFpsEstimator()
+        estimator.sample(10, 1_000_000_000)
+
+        assertEquals(60f, estimator.sample(70, 2_000_000_000)!!, 0.001f)
+    }
+
+    @Test
+    fun `time must move forward`() {
+        val estimator = FrameCountFpsEstimator()
+        estimator.sample(10, 2_000_000_000)
+
+        assertNull(estimator.sample(70, 2_000_000_000))
+    }
+
+    @Test
+    fun `a decreasing count restarts the baseline`() {
+        val estimator = FrameCountFpsEstimator()
+        estimator.sample(70, 1_000_000_000)
+
+        assertNull(estimator.sample(10, 2_000_000_000))
+        assertEquals(30f, estimator.sample(40, 3_000_000_000)!!, 0.001f)
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/runner/GameFpsAdvisorTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/GameFpsAdvisorTest.kt
@@ -1,0 +1,75 @@
+package com.aliothmoon.maafw.runner
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GameFpsAdvisorTest {
+
+    private fun samples(lowCount: Int, highFps: Float = 60f): List<Float> =
+        List(GameFpsAdvisor.DEFAULT_WINDOW_SIZE) { index ->
+            if (index < lowCount) 25f else highFps
+        }
+
+    @Test
+    fun `fewer than eighty percent low samples do not advise`() {
+        val advisor = GameFpsAdvisor()
+
+        samples(lowCount = 11).forEach { assertNull(advisor.onSample(it)) }
+    }
+
+    @Test
+    fun `eighty percent low samples advise with the window median`() {
+        val advisor = GameFpsAdvisor()
+        var advice: GameFpsAdvisor.Advice? = null
+
+        samples(lowCount = 12).forEach { sample -> advice = advisor.onSample(sample) ?: advice }
+        val result = advice ?: error("Expected low FPS advice")
+
+        assertEquals(GameFpsAdvisor.Level.LOW, result.level)
+        assertEquals(25f, result.medianFps, 0.001f)
+    }
+
+    @Test
+    fun `each level advises only once`() {
+        val advisor = GameFpsAdvisor()
+        var low: GameFpsAdvisor.Advice? = null
+        var degraded: GameFpsAdvisor.Advice? = null
+
+        samples(lowCount = 15).forEach { sample -> low = advisor.onSample(sample) ?: low }
+        assertEquals(GameFpsAdvisor.Level.LOW, low!!.level)
+        repeat(5) { assertNull(advisor.onSample(25f)) }
+
+        samples(lowCount = 0, highFps = 40f).forEach { sample ->
+            degraded = advisor.onSample(sample) ?: degraded
+        }
+        assertEquals(GameFpsAdvisor.Level.DEGRADED, degraded!!.level)
+        assertNull(advisor.onSample(40f))
+    }
+
+    @Test
+    fun `short idle streaks are ignored and longer streaks clear the window`() {
+        val advisor = GameFpsAdvisor()
+        samples(lowCount = 12).take(12).forEach { advisor.onSample(it) }
+        repeat(3) { assertNull(advisor.onSample(0f)) }
+
+        assertNull(advisor.onSample(25f))
+        assertNull(advisor.onSample(25f))
+
+        repeat(4) { advisor.onSample(0f) }
+        repeat(14) { assertNull(advisor.onSample(25f)) }
+        assertEquals(GameFpsAdvisor.Level.LOW, advisor.onSample(25f)!!.level)
+    }
+
+    @Test
+    fun `reset forgets previous advice`() {
+        val advisor = GameFpsAdvisor()
+        samples(lowCount = 15).forEach { advisor.onSample(it) }
+
+        advisor.reset()
+
+        var advice: GameFpsAdvisor.Advice? = null
+        samples(lowCount = 15).forEach { sample -> advice = advisor.onSample(sample) ?: advice }
+        assertEquals(GameFpsAdvisor.Level.LOW, advice!!.level)
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/runner/GameFpsHookTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/GameFpsHookTest.kt
@@ -1,0 +1,74 @@
+package com.aliothmoon.maafw.runner
+
+import com.aliothmoon.maafw.domain.ControllerDefinition
+import com.aliothmoon.maafw.domain.ResourceDefinition
+import com.aliothmoon.maafw.domain.RunConfigurationId
+import com.aliothmoon.maafw.domain.RunMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameFpsHookTest {
+
+    private val plan = RunPlan(
+        projectName = "demo",
+        projectVersion = "1",
+        controller = ControllerDefinition(),
+        resource = ResourceDefinition("官服", listOf("./base")),
+        runConfigurationId = RunConfigurationId("c1"),
+        tasks = emptyList(),
+    )
+
+    private fun context(runMode: RunMode) =
+        RunContext(RunTrigger.Manual, runMode, plan, journal = DiscardingRunJournal)
+
+    @Test
+    fun `foreground runs do not poll`() = runTest {
+        val reader = object : GameFpsReader {
+            var reads = 0
+                private set
+
+            override suspend fun readGameFps(): Float? {
+                reads++
+                return 60f
+            }
+        }
+        val watcher = GameFpsWatcher(reader, DiscardingRunJournal, backgroundScope)
+
+        assertTrue(GameFpsHook(watcher).engage(context(RunMode.FOREGROUND)) is EngageResult.Skipped)
+        advanceTimeBy(5_000)
+
+        assertEquals(0, reader.reads)
+    }
+
+    @Test
+    fun `background runs engage and release the watcher`() = runTest {
+        val reader = object : GameFpsReader {
+            var reads = 0
+                private set
+
+            override suspend fun readGameFps(): Float? {
+                reads++
+                return 60f
+            }
+        }
+        val watcher = GameFpsWatcher(reader, DiscardingRunJournal, backgroundScope)
+        val hook = GameFpsHook(watcher)
+
+        val result = hook.engage(context(RunMode.BACKGROUND))
+        advanceTimeBy(1_001)
+        assertEquals(1, reader.reads)
+        assertEquals(60f, watcher.fps.value)
+
+        (result as EngageResult.Engaged).release(RunEndReason.Ran(ExecutionResult.Completed(emptyList())))
+        val readsAtRelease = reader.reads
+        advanceTimeBy(2_000)
+        assertEquals(readsAtRelease, reader.reads)
+        assertNull(watcher.fps.value)
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/runner/GameFpsWatcherTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/GameFpsWatcherTest.kt
@@ -1,0 +1,91 @@
+package com.aliothmoon.maafw.runner
+
+import com.aliothmoon.maafw.i18n.UiText
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameFpsWatcherTest {
+
+    private class QueueReader(vararg values: Float?) : GameFpsReader {
+        private val queue = ArrayDeque(values.toList())
+        var readCount = 0
+            private set
+
+        override suspend fun readGameFps(): Float? {
+            readCount++
+            return queue.removeFirstOrNull() ?: queue.lastOrNull()
+        }
+    }
+
+    private class RecordingJournal : RunJournal {
+        val notes = mutableListOf<Pair<RunNote, UiText>>()
+
+        override suspend fun begin(plan: RunPlan) = Unit
+        override suspend fun end(reason: RunEndReason) = Unit
+        override fun note(level: RunNote, text: UiText) {
+            notes += level to text
+        }
+    }
+
+    @Test
+    fun `polling publishes valid values and unknown clears the display`() = runTest {
+        val reader = QueueReader(60f, null)
+        val watcher = GameFpsWatcher(reader, DiscardingRunJournal, backgroundScope)
+
+        watcher.start()
+        advanceTimeBy(1_001)
+        assertEquals(60f, watcher.fps.value)
+
+        advanceTimeBy(1_000)
+        assertNull(watcher.fps.value)
+
+        watcher.stop()
+        assertEquals(2, reader.readCount)
+    }
+
+    @Test
+    fun `sustained low fps logs once`() = runTest {
+        val journal = RecordingJournal()
+        val watcher = GameFpsWatcher(object : GameFpsReader {
+            override suspend fun readGameFps(): Float? = 25f
+        }, journal, backgroundScope)
+
+        repeat(15) { watcher.pollOnce() }
+        repeat(5) { watcher.pollOnce() }
+
+        assertEquals(1, journal.notes.size)
+        assertEquals(RunNote.Error, journal.notes.single().first)
+    }
+
+    @Test
+    fun `sustained degraded fps logs a warning`() = runTest {
+        val journal = RecordingJournal()
+        val watcher = GameFpsWatcher(object : GameFpsReader {
+            override suspend fun readGameFps(): Float? = 40f
+        }, journal, backgroundScope)
+
+        repeat(15) { watcher.pollOnce() }
+
+        assertEquals(listOf(RunNote.Warning), journal.notes.map { it.first })
+    }
+
+    @Test
+    fun `unreadable remote does not log low fps`() = runTest {
+        val journal = RecordingJournal()
+        val watcher = GameFpsWatcher(object : GameFpsReader {
+            override suspend fun readGameFps(): Float? = null
+        }, journal, backgroundScope)
+
+        repeat(GameFpsAdvisor.DEFAULT_WINDOW_SIZE + GameFpsAdvisor.DEFAULT_MAX_IDLE_STREAK) {
+            watcher.pollOnce()
+        }
+
+        assertNull(watcher.fps.value)
+        assertEquals(emptyList<Pair<RunNote, UiText>>(), journal.notes)
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -43,6 +43,8 @@ import com.aliothmoon.maafw.runner.FocusChannel
 import com.aliothmoon.maafw.runner.FocusContentResolver
 import com.aliothmoon.maafw.runner.FocusDispatcher
 import com.aliothmoon.maafw.runner.FocusMessage
+import com.aliothmoon.maafw.runner.GameFpsReader
+import com.aliothmoon.maafw.runner.GameFpsWatcher
 import com.aliothmoon.maafw.runner.PassthroughFocusContentResolver
 import com.aliothmoon.maafw.runner.RunLogKind
 import com.aliothmoon.maafw.runner.isEssential
@@ -197,6 +199,13 @@ class SessionViewModelTest {
             appSettings = settings,
             focusDispatcher = focusDispatcher,
             recorder = recorderFor(runner, focusDispatcher),
+            gameFpsWatcher = GameFpsWatcher(
+                object : GameFpsReader {
+                    override suspend fun readGameFps(): Float? = 60f
+                },
+                DiscardingRunJournal,
+                backgroundScope,
+            ),
             piInstall = emptyPiInstall(),
         )
         return Triple(vm, store, runner)
@@ -222,6 +231,13 @@ class SessionViewModelTest {
             appSettings = settings,
             focusDispatcher = focusDispatcher,
             recorder = recorderFor(runner, focusDispatcher),
+            gameFpsWatcher = GameFpsWatcher(
+                object : GameFpsReader {
+                    override suspend fun readGameFps(): Float? = 60f
+                },
+                DiscardingRunJournal,
+                backgroundScope,
+            ),
             piInstall = emptyPiInstall(),
         )
     }

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -5,6 +5,7 @@ import com.aliothmoon.maafw.config.InMemoryUserConfigurationStore
 import com.aliothmoon.maafw.constant.AppPaths
 import com.aliothmoon.maafw.domain.ConfiguredTask
 import com.aliothmoon.maafw.domain.ControllerDefinition
+import com.aliothmoon.maafw.domain.OptionValue
 import com.aliothmoon.maafw.domain.ProjectDefinition
 import com.aliothmoon.maafw.domain.ResourceDefinition
 import com.aliothmoon.maafw.domain.RunConfiguration
@@ -418,6 +419,40 @@ class SessionViewModelTest {
     }
 
     @Test
+    fun `reset task list clears options only for selected configuration`() = runTest(mainDispatcher) {
+        val activeId = RunConfigurationId("c1")
+        val otherId = RunConfigurationId("c2")
+        val optionValues = mapOf("option" to OptionValue.SingleCase("custom"))
+        val store = InMemoryUserConfigurationStore(
+            UserConfiguration(
+                initialized = true,
+                activeResourceName = "官服",
+                configurations = listOf(
+                    RunConfiguration(
+                        activeId,
+                        "日常",
+                        listOf(ConfiguredTask("启动游戏", optionValues = optionValues, instanceId = "t1")),
+                    ),
+                    RunConfiguration(
+                        otherId,
+                        "备份",
+                        listOf(ConfiguredTask("启动游戏", optionValues = optionValues, instanceId = "t2")),
+                    ),
+                ),
+                activeConfigurationId = activeId,
+            ),
+        )
+        val (vm, _, _) = createVm(store = store)
+        advanceUntilIdle()
+
+        vm.onIntent(SessionIntent.ResetTaskList(activeId))
+        advanceUntilIdle()
+
+        assertTrue(store.current.configurations[0].tasks.single().optionValues.isEmpty())
+        assertEquals(optionValues, store.current.configurations[1].tasks.single().optionValues)
+    }
+
+    @Test
     fun `busy runner rejects configuration mutation`() = runTest(mainDispatcher) {
         val runner = StubRunnerPort(
             scope = backgroundScope,
@@ -444,6 +479,37 @@ class SessionViewModelTest {
                     it.message.isResource(R.string.msg_locked_while_running)
             },
         )
+    }
+
+    @Test
+    fun `reset task list is blocked while busy`() = runTest(mainDispatcher) {
+        val runner = StubRunnerPort(
+            scope = backgroundScope,
+            scenario = StubRunnerScenario(prepareDelayMillis = 60_000, taskDelayMillis = 60_000),
+        )
+        val configId = RunConfigurationId("c1")
+        val initialStore = readyStore(
+            configId = configId,
+            tasks = listOf(
+                ConfiguredTask(
+                    "启动游戏",
+                    optionValues = mapOf("option" to OptionValue.SingleCase("custom")),
+                    instanceId = "t1",
+                ),
+            ),
+        )
+        val (vm, updatedStore, _) = createVm(store = initialStore, runner = runner)
+        advanceUntilIdle()
+
+        vm.onIntent(SessionIntent.Start())
+        advanceUntilIdle()
+        assertTrue(runner.state.value.phase.isBusy)
+        val before = updatedStore.current
+
+        vm.onIntent(SessionIntent.ResetTaskList(configId))
+        advanceUntilIdle()
+
+        assertEquals(before, updatedStore.current)
     }
 
     @Test


### PR DESCRIPTION
## 摘要
- 快捷操作中的刷新入口改为重置当前任务列表，不再触发项目重载
- 清空当前配置内任务的参数覆盖，使任务选项回落到接口定义的默认值
- 任务序列唯一匹配预设时恢复预设勾选状态；同时保留任务顺序、实例 ID 与别名
- 补充配置解析与 Session 写入、运行中拦截的单元测试

## 测试
- ./gradlew :app:testDebugUnitTest --rerun-tasks
- git diff --cached --check