### PR TITLE
feat：记录输入注入失败详情

### DIFF
--- a/app/src/main/java/com/aliothmoon/maafw/bridge/InputControlUtils.java
+++ b/app/src/main/java/com/aliothmoon/maafw/bridge/InputControlUtils.java
@@ -85,11 +85,33 @@ public final class InputControlUtils {
      */
     private static boolean inject(MotionEvent event, int displayId, int mode, int reportIndex) {
         try {
+            long setDisplayStartNanos = SystemClock.elapsedRealtimeNanos();
+            long injectStartNanos = 0;
             if (!setDisplayId(event, displayId)) {
+                logTouchInjectionFailure(
+                        event,
+                        reportIndex,
+                        displayId,
+                        mode,
+                        "SET_DISPLAY_ID",
+                        setDisplayStartNanos,
+                        injectStartNanos);
                 return false;
             }
             notifyTouchCallback(event, reportIndex);
-            return getManager().injectInputEvent(event, mode);
+            injectStartNanos = SystemClock.elapsedRealtimeNanos();
+            boolean injected = getManager().injectInputEvent(event, mode);
+            if (!injected) {
+                logTouchInjectionFailure(
+                        event,
+                        reportIndex,
+                        displayId,
+                        mode,
+                        "INJECT_INPUT_EVENT",
+                        setDisplayStartNanos,
+                        injectStartNanos);
+            }
+            return injected;
         } finally {
             event.recycle();
         }
@@ -141,6 +163,108 @@ public final class InputControlUtils {
         slots = Collections.emptyList();
     }
 
+    private static String formatSlots(List<TouchPointerSequence.Pointer> pointers) {
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < pointers.size(); i++) {
+            TouchPointerSequence.Pointer pointer = pointers.get(i);
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(pointer.getContact())
+                    .append(':')
+                    .append(pointer.getX())
+                    .append(',')
+                    .append(pointer.getY());
+        }
+        return builder.append(']').toString();
+    }
+
+    private static String formatPointers(MotionEvent event) {
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < event.getPointerCount(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(event.getPointerId(i))
+                    .append(':')
+                    .append(event.getX(i))
+                    .append(',')
+                    .append(event.getY(i));
+        }
+        return builder.append(']').toString();
+    }
+
+    private static String actionName(int maskedAction) {
+        switch (maskedAction) {
+            case MotionEvent.ACTION_DOWN: return "DOWN";
+            case MotionEvent.ACTION_UP: return "UP";
+            case MotionEvent.ACTION_MOVE: return "MOVE";
+            case MotionEvent.ACTION_CANCEL: return "CANCEL";
+            case MotionEvent.ACTION_POINTER_DOWN: return "POINTER_DOWN";
+            case MotionEvent.ACTION_POINTER_UP: return "POINTER_UP";
+            default: return "UNKNOWN_" + maskedAction;
+        }
+    }
+
+    private static String injectModeName(int mode) {
+        switch (mode) {
+            case InputManager.INJECT_INPUT_EVENT_MODE_ASYNC: return "ASYNC";
+            case InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_RESULT: return "WAIT_FOR_RESULT";
+            case InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH: return "WAIT_FOR_FINISH";
+            default: return "UNKNOWN_" + mode;
+        }
+    }
+
+    private static String elapsedMs(long startNanos) {
+        return String.valueOf((SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000.0);
+    }
+
+    private static void logPlanFailure(
+            TouchPointerSequence.Step step,
+            TouchPointerSequence.Kind kind,
+            int x,
+            int y,
+            int contact,
+            int displayId
+    ) {
+        Ln.w(TAG + ": touch plan failed"
+                + " reason=" + step.getFailureReason()
+                + " kind=" + kind
+                + " displayId=" + displayId
+                + " contact=" + contact
+                + " x=" + x
+                + " y=" + y
+                + " slots=" + formatSlots(slots));
+    }
+
+    private static void logTouchInjectionFailure(
+            MotionEvent event,
+            int reportIndex,
+            int displayId,
+            int mode,
+            String stage,
+            long setDisplayStartNanos,
+            long injectStartNanos
+    ) {
+        int index = Math.min(reportIndex, Math.max(0, event.getPointerCount() - 1));
+        Ln.w(TAG + ": touch inject failed"
+                + " stage=" + stage
+                + " action=" + actionName(event.getActionMasked())
+                + " actionRaw=" + event.getAction()
+                + " requestedDisplayId=" + displayId
+                + " eventDisplayId=" + InputManager.getDisplayIdForLog(event)
+                + " changingIndex=" + index
+                + " changingContact=" + event.getPointerId(index)
+                + " x=" + event.getX(index)
+                + " y=" + event.getY(index)
+                + " pointers=" + formatPointers(event)
+                + " mode=" + injectModeName(mode)
+                + " setDisplayElapsedMs=" + elapsedMs(setDisplayStartNanos)
+                + " injectElapsedMs=" + (injectStartNanos == 0 ? "not_reached" : elapsedMs(injectStartNanos))
+                + " gestureDownTime=" + event.getDownTime()
+                + " eventTime=" + event.getEventTime());
+    }
+
     private static boolean injectStep(TouchPointerSequence.Step step, int displayId) {
         if (!step.getOk()) {
             return false;
@@ -179,7 +303,12 @@ public final class InputControlUtils {
 
     private static synchronized boolean apply(TouchPointerSequence.Kind kind, int x, int y, int contact,
                                               int displayId) {
-        return injectStep(TouchPointerSequence.INSTANCE.plan(kind, slots, contact, x, y), displayId);
+        TouchPointerSequence.Step step = TouchPointerSequence.INSTANCE.plan(kind, slots, contact, x, y);
+        if (!step.getOk()) {
+            logPlanFailure(step, kind, x, y, contact, displayId);
+            return false;
+        }
+        return injectStep(step, displayId);
     }
 
     public static boolean down(int x, int y, int contact, int displayId) {
@@ -198,20 +327,88 @@ public final class InputControlUtils {
         long downTime = SystemClock.uptimeMillis();
         KeyEvent keyEvent = new KeyEvent(downTime, downTime, KeyEvent.ACTION_DOWN, keyCode, 0);
 
+        long setDisplayStartNanos = SystemClock.elapsedRealtimeNanos();
+        long injectStartNanos;
         if (!setDisplayId(keyEvent, displayId)) {
+            logKeyInjectionFailure(
+                    keyEvent,
+                    keyCode,
+                    displayId,
+                    "WAIT_FOR_FINISH",
+                    "SET_DISPLAY_ID",
+                    setDisplayStartNanos,
+                    0);
             return false;
         }
-        return getManager().injectInputEvent(keyEvent, InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH);
+        injectStartNanos = SystemClock.elapsedRealtimeNanos();
+        boolean injected = getManager().injectInputEvent(
+                keyEvent,
+                InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH);
+        if (!injected) {
+            logKeyInjectionFailure(
+                    keyEvent,
+                    keyCode,
+                    displayId,
+                    "WAIT_FOR_FINISH",
+                    "INJECT_INPUT_EVENT",
+                    setDisplayStartNanos,
+                    injectStartNanos);
+        }
+        return injected;
     }
 
     public static boolean keyUp(int keyCode, int displayId) {
         long upTime = SystemClock.uptimeMillis();
         KeyEvent keyEvent = new KeyEvent(upTime, upTime, KeyEvent.ACTION_UP, keyCode, 0);
 
+        long setDisplayStartNanos = SystemClock.elapsedRealtimeNanos();
+        long injectStartNanos;
         if (!setDisplayId(keyEvent, displayId)) {
+            logKeyInjectionFailure(
+                    keyEvent,
+                    keyCode,
+                    displayId,
+                    "ASYNC",
+                    "SET_DISPLAY_ID",
+                    setDisplayStartNanos,
+                    0);
             return false;
         }
 
-        return getManager().injectInputEvent(keyEvent, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+        injectStartNanos = SystemClock.elapsedRealtimeNanos();
+        boolean injected = getManager().injectInputEvent(keyEvent, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+        if (!injected) {
+            logKeyInjectionFailure(
+                    keyEvent,
+                    keyCode,
+                    displayId,
+                    "ASYNC",
+                    "INJECT_INPUT_EVENT",
+                    setDisplayStartNanos,
+                    injectStartNanos);
+        }
+        return injected;
+    }
+
+    private static void logKeyInjectionFailure(
+            KeyEvent event,
+            int keyCode,
+            int displayId,
+            String mode,
+            String stage,
+            long setDisplayStartNanos,
+            long injectStartNanos
+    ) {
+        Ln.w(TAG + ": key inject failed"
+                + " stage=" + stage
+                + " action=" + (event.getAction() == KeyEvent.ACTION_DOWN ? "DOWN" : "UP")
+                + " keyCode=" + keyCode
+                + " requestedDisplayId=" + displayId
+                + " eventDisplayId=" + InputManager.getDisplayIdForLog(event)
+                + " mode=" + mode
+                + " setDisplayElapsedMs=" + elapsedMs(setDisplayStartNanos)
+                + " injectElapsedMs=" + (injectStartNanos == 0 ? "not_reached" : elapsedMs(injectStartNanos))
+                + " downTime=" + event.getDownTime()
+                + " eventTime=" + event.getEventTime());
     }
 }

--- a/app/src/main/java/com/aliothmoon/maafw/bridge/TouchPointerSequence.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/bridge/TouchPointerSequence.kt
@@ -19,6 +19,8 @@ object TouchPointerSequence {
 
     enum class Kind { Down, Move, Up }
 
+    enum class FailureReason { InvalidContact, MissingContact, TooManyContacts }
+
     data class Pointer(
         val contact: Int,
         val x: Float,
@@ -31,6 +33,7 @@ object TouchPointerSequence {
         val changingIndex: Int = 0,
         val pointers: List<Pointer> = emptyList(),
         val cancelFirst: Boolean = false,
+        val failureReason: FailureReason? = null,
     )
 
     fun plan(
@@ -40,7 +43,9 @@ object TouchPointerSequence {
         x: Float,
         y: Float,
     ): Step {
-        if (contact !in 0..<MAX_CONTACTS) return Step(ok = false)
+        if (contact !in 0..<MAX_CONTACTS) {
+            return Step(ok = false, failureReason = FailureReason.InvalidContact)
+        }
         val idx = current.indexOfFirst { it.contact == contact }
         val nextPointer = Pointer(contact, x, y)
         return when (kind) {
@@ -59,7 +64,9 @@ object TouchPointerSequence {
                     pointers = listOf(nextPointer),
                 )
 
-                current.size >= MAX_CONTACTS -> Step(ok = false)
+                current.size >= MAX_CONTACTS -> {
+                    Step(ok = false, failureReason = FailureReason.TooManyContacts)
+                }
                 else -> {
                     val next = current + nextPointer
                     Step(
@@ -72,14 +79,18 @@ object TouchPointerSequence {
             }
 
             Kind.Move -> {
-                if (idx < 0) return Step(ok = false)
+                if (idx < 0) {
+                    return Step(ok = false, failureReason = FailureReason.MissingContact)
+                }
                 val next = current.toMutableList()
                 next[idx] = nextPointer
                 Step(ok = true, actionMasked = ACTION_MOVE, changingIndex = idx, pointers = next)
             }
 
             Kind.Up -> {
-                if (idx < 0) return Step(ok = false)
+                if (idx < 0) {
+                    return Step(ok = false, failureReason = FailureReason.MissingContact)
+                }
                 val next = current.toMutableList()
                 next[idx] = nextPointer
                 if (current.size == 1) {

--- a/app/src/main/java/com/aliothmoon/maafw/third/wrappers/InputManager.java
+++ b/app/src/main/java/com/aliothmoon/maafw/third/wrappers/InputManager.java
@@ -2,7 +2,9 @@ package com.aliothmoon.maafw.third.wrappers;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.os.SystemClock;
 import android.view.InputEvent;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 
 import com.aliothmoon.maafw.constant.AndroidVersions;
@@ -24,6 +26,7 @@ public final class InputManager {
 
     private static Method injectInputEventMethod;
     private static Method setDisplayIdMethod;
+    private static Method getDisplayIdMethod;
     private static Method setActionButtonMethod;
     private static Method addUniqueIdAssociationByPortMethod;
     private static Method removeUniqueIdAssociationByPortMethod;
@@ -46,9 +49,18 @@ public final class InputManager {
     }
 
     public boolean injectInputEvent(InputEvent inputEvent, int mode) {
+        long startNanos = SystemClock.elapsedRealtimeNanos();
         try {
             Method method = getInjectInputEventMethod();
-            return (boolean) method.invoke(manager, inputEvent, mode);
+            boolean injected = (boolean) method.invoke(manager, inputEvent, mode);
+            if (!injected) {
+                Ln.w("injectInputEvent returned false"
+                        + " event=" + describeInputEvent(inputEvent)
+                        + " displayId=" + getDisplayIdForLog(inputEvent)
+                        + " mode=" + mode
+                        + " elapsedMs=" + (SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000.0);
+            }
+            return injected;
         } catch (ReflectiveOperationException e) {
             if (e instanceof InvocationTargetException) {
                 Throwable cause = e.getCause();
@@ -59,16 +71,57 @@ public final class InputManager {
                         long now = System.currentTimeMillis();
                         if (lastPermissionLogDate <= now - 3000) {
                             Ln.e(message);
-                            Ln.e("Make sure you have enabled \"USB debugging (Security Settings)\" and then rebooted your device.");
+                            Ln.e("Make sure you have enabled \"USB debugging (Security Settings)\""
+                                    + " and then rebooted your device.");
                             lastPermissionLogDate = now;
                         }
+                        Ln.w("injectInputEvent invocation rejected"
+                                + " event=" + describeInputEvent(inputEvent)
+                                + " displayId=" + getDisplayIdForLog(inputEvent)
+                                + " mode=" + mode
+                                + " cause=" + cause.getClass().getName()
+                                + ":" + cause.getMessage()
+                                + " elapsedMs="
+                                + (SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000.0);
                         // Do not print the stack trace
                         return false;
                     }
                 }
             }
-            Ln.e("Could not invoke method", e);
+            Ln.e("Could not invoke injectInputEvent"
+                            + " event=" + describeInputEvent(inputEvent)
+                            + " displayId=" + getDisplayIdForLog(inputEvent)
+                            + " mode=" + mode,
+                    e);
             return false;
+        }
+    }
+
+    private static String describeInputEvent(InputEvent inputEvent) {
+        if (inputEvent instanceof MotionEvent) {
+            MotionEvent event = (MotionEvent) inputEvent;
+            return "MotionEvent(action=" + event.getActionMasked()
+                    + ",actionRaw=" + event.getAction()
+                    + ",pointerCount=" + event.getPointerCount()
+                    + ')';
+        }
+        if (inputEvent instanceof KeyEvent) {
+            KeyEvent event = (KeyEvent) inputEvent;
+            return "KeyEvent(action=" + event.getAction()
+                    + ",keyCode=" + event.getKeyCode()
+                    + ')';
+        }
+        return inputEvent.getClass().getName();
+    }
+
+    public static String getDisplayIdForLog(InputEvent inputEvent) {
+        try {
+            if (getDisplayIdMethod == null) {
+                getDisplayIdMethod = InputEvent.class.getMethod("getDisplayId");
+            }
+            return String.valueOf(getDisplayIdMethod.invoke(inputEvent));
+        } catch (ReflectiveOperationException e) {
+            return "unavailable:" + e.getClass().getSimpleName();
         }
     }
 
@@ -85,7 +138,11 @@ public final class InputManager {
             method.invoke(inputEvent, displayId);
             return true;
         } catch (ReflectiveOperationException e) {
-            Ln.e("Cannot associate a display id to the input event", e);
+            Ln.e("Cannot associate a display id to the input event"
+                            + " requestedDisplayId=" + displayId
+                            + " eventDisplayId=" + getDisplayIdForLog(inputEvent)
+                            + " event=" + describeInputEvent(inputEvent),
+                    e);
             return false;
         }
     }

--- a/app/src/test/java/com/aliothmoon/maafw/bridge/TouchPointerSequenceTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/bridge/TouchPointerSequenceTest.kt
@@ -1,5 +1,6 @@
 package com.aliothmoon.maafw.bridge
 
+import com.aliothmoon.maafw.bridge.TouchPointerSequence.FailureReason
 import com.aliothmoon.maafw.bridge.TouchPointerSequence.Kind
 import com.aliothmoon.maafw.bridge.TouchPointerSequence.Pointer
 import org.junit.Assert.assertEquals
@@ -91,21 +92,39 @@ class TouchPointerSequenceTest {
 
     @Test
     fun `move or up without that contact is rejected`() {
-        assertFalse(TouchPointerSequence.plan(Kind.Move, listOf(p(0)), 1, 0f, 0f).ok)
-        assertFalse(TouchPointerSequence.plan(Kind.Up, listOf(p(0)), 1, 0f, 0f).ok)
+        val move = TouchPointerSequence.plan(Kind.Move, listOf(p(0)), 1, 0f, 0f)
+        val up = TouchPointerSequence.plan(Kind.Up, listOf(p(0)), 1, 0f, 0f)
+
+        assertFalse(move.ok)
+        assertEquals(FailureReason.MissingContact, move.failureReason)
+        assertFalse(up.ok)
+        assertEquals(FailureReason.MissingContact, up.failureReason)
     }
 
     @Test
     fun `out of range contact is rejected`() {
-        assertFalse(TouchPointerSequence.plan(Kind.Down, emptyList(), -1, 0f, 0f).ok)
-        assertFalse(
+        val negative = TouchPointerSequence.plan(Kind.Down, emptyList(), -1, 0f, 0f)
+        val tooLarge =
             TouchPointerSequence.plan(
                 Kind.Down,
                 emptyList(),
                 TouchPointerSequence.MAX_CONTACTS,
                 0f,
                 0f,
-            ).ok,
-        )
+            )
+
+        assertFalse(negative.ok)
+        assertEquals(FailureReason.InvalidContact, negative.failureReason)
+        assertFalse(tooLarge.ok)
+        assertEquals(FailureReason.InvalidContact, tooLarge.failureReason)
+    }
+
+    @Test
+    fun `adding another contact beyond capacity is rejected`() {
+        val current = List(TouchPointerSequence.MAX_CONTACTS) { p(1) }
+        val step = TouchPointerSequence.plan(Kind.Down, current, 0, 0f, 0f)
+
+        assertFalse(step.ok)
+        assertEquals(FailureReason.TooManyContacts, step.failureReason)
     }
 }


### PR DESCRIPTION
## 摘要
- 为触摸序列规划失败补充分类原因，并记录当前 contact/slot 状态
- 在绑定 displayId 和实际注入输入两个阶段分别记录触摸、按键失败
- 记录事件所属 displayId、指针/按键信息、注入模式和耗时
- 为新增失败原因补充单元测试

## 测试
- ./gradlew :app:testDebugUnitTest --tests com.aliothmoon.maafw.bridge.TouchPointerSequenceTest