### PR TITLE
feat: show multiple welcome announcements

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -64,7 +64,7 @@ app:
 | 热更新资源 | 资源随 APK 绑定，换资源重新出包 |
 | 调试期改完资源刷新即可 | 重装或清数据。版本号在独立 checkout 时跟本仓库提交走、作为 submodule 时跟最外层主仓库走；版本号未变时设备可能继续用旧解包 |
 
-`welcome`、`description`、`contact`、`license`、`github`、`telemetry` 会进首启弹窗和设置页「关于」。正文支持 `$i18n`、相对文件、URL 或直接文本。
+`welcome`、`description`、`contact`、`license`、`github`、`telemetry` 会进首启弹窗和设置页「关于」。正文支持 `$i18n`、相对文件、URL 或直接文本。PI v2.10.2 起 `welcome` 还支持非空字符串数组，多条公告会按声明顺序展示。
 
 ## Agent
 

--- a/app/src/main/java/com/aliothmoon/maafw/domain/Diagnostics.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/domain/Diagnostics.kt
@@ -70,6 +70,8 @@ object DiagnosticMessages {
     fun languagePathInvalid(language: String): UiText =
         uiTextOf(R.string.diagnostic_language_path_invalid, language)
 
+    fun welcomeInvalid(): UiText = uiTextOf(R.string.diagnostic_welcome_invalid)
+
     fun importReadFailed(detail: String): UiText =
         uiTextOf(R.string.diagnostic_import_read_failed, detail)
 

--- a/app/src/main/java/com/aliothmoon/maafw/domain/ProjectDefinition.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/domain/ProjectDefinition.kt
@@ -41,10 +41,10 @@ data class TelemetryDefinition(
 )
 
 /**
- * [welcomeFingerprint] 算在物化前的原始声明上：算在正文上的话，切一次语言换了译文就会重弹
+ * [welcomeFingerprint] 算在物化前的完整有序声明上：算在正文上的话，切一次语言换了译文就会重弹
  */
 data class ProjectMetadata(
-    val welcome: String? = null,
+    val welcome: List<String> = emptyList(),
     val welcomeFingerprint: String? = null,
     val description: String? = null,
     val contact: String? = null,

--- a/app/src/main/java/com/aliothmoon/maafw/project/PiParser.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/project/PiParser.kt
@@ -246,11 +246,21 @@ object PiParser {
     }
 
     /** 与 [parseInterface] 分开是因为物化要等翻译表，那一步在 loader 里读完 languages 才有 */
-    fun parseMetadata(root: JsonObject, text: PiTextResolver): ProjectMetadata {
-        val welcomeRaw = root.string("welcome")
+    fun parseMetadata(root: JsonObject, text: PiTextResolver): ProjectMetadata =
+        parseMetadata("welcome", root, text, mutableListOf())
+
+    fun parseMetadata(
+        source: String,
+        root: JsonObject,
+        text: PiTextResolver,
+        diagnostics: MutableList<Diagnostic>,
+    ): ProjectMetadata {
+        val welcomeRaw = welcomeDeclarations(source, root, diagnostics)
         return ProjectMetadata(
-            welcome = text.description(welcomeRaw),
-            welcomeFingerprint = welcomeRaw?.let { welcomeFingerprint(it, root.string("version")) },
+            welcome = welcomeRaw.map { text.description(it).orEmpty() },
+            welcomeFingerprint = welcomeRaw
+                .takeIf { it.isNotEmpty() }
+                ?.let { welcomeFingerprint(it, root.string("version")) },
             description = text.description(root.string("description")),
             contact = text.description(root.string("contact")),
             license = text.description(root.string("license")),
@@ -260,6 +270,39 @@ object PiParser {
                 ?.takeIf(String::isNotBlank),
             mirrorchyanRid = root.string("mirrorchyan_rid")?.trim()?.takeIf(String::isNotBlank),
         )
+    }
+
+    /** PI v2.10.2：welcome 允许 string 或非空 string[]，统一成有序公告列表 */
+    private fun welcomeDeclarations(
+        source: String,
+        root: JsonObject,
+        diagnostics: MutableList<Diagnostic>,
+    ): List<String> = when (val value = root["welcome"]) {
+        null -> emptyList()
+        is JsonPrimitive -> value
+            .takeIf { it.isString }
+            ?.contentOrNull
+            ?.let(::listOf)
+            ?: invalidWelcome(source, diagnostics)
+        is JsonArray -> {
+            val declarations = value.mapNotNull { element ->
+                (element as? JsonPrimitive)
+                    ?.takeIf { it.isString }
+                    ?.contentOrNull
+            }
+            when {
+                declarations.size != value.size -> invalidWelcome(source, diagnostics)
+                declarations.isEmpty() -> invalidWelcome(source, diagnostics)
+                else -> declarations
+            }
+        }
+
+        else -> invalidWelcome(source, diagnostics)
+    }
+
+    private fun invalidWelcome(source: String, diagnostics: MutableList<Diagnostic>): List<String> {
+        diagnostics += error(source, DiagnosticMessages.welcomeInvalid())
+        return emptyList()
     }
 
     /** 只认 github.com/<owner>/<repo>；仓库页 URL 常带 release 等后续路径，都截掉 */
@@ -282,11 +325,33 @@ object PiParser {
         )
     }
 
-    private fun welcomeFingerprint(raw: String, version: String?): String =
+    private fun welcomeFingerprint(raw: List<String>, version: String?): String =
         MessageDigest.getInstance("SHA-256")
-            .digest("$raw@${version.orEmpty()}".toByteArray())
+            .digest(welcomeFingerprintPayload(raw, version).toByteArray())
             .take(8)
             .joinToString("") { "%02x".format(it) }
+
+    /**
+     * 单条公告沿用旧 payload，保证旧单字符串与新的等价单元素数组不重复弹窗；
+     * 多条公告用长度前缀编码，避免用分隔符拼接时产生歧义
+     */
+    private fun welcomeFingerprintPayload(raw: List<String>, version: String?): String {
+        val normalizedVersion = version.orEmpty()
+        if (raw.size == 1) return "${raw.single()}@$normalizedVersion"
+        return buildString {
+            append(raw.size)
+            raw.forEach { item ->
+                append('|')
+                append(item.length)
+                append('|')
+                append(item)
+            }
+            append("|@")
+            append(normalizedVersion.length)
+            append('|')
+            append(normalizedVersion)
+        }
+    }
 
     fun parseFile(source: String, content: String, text: PiTextResolver): PiFileContent {
         val root = try {

--- a/app/src/main/java/com/aliothmoon/maafw/project/ProjectLoader.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/project/ProjectLoader.kt
@@ -156,7 +156,9 @@ class ProjectLoader(
             globalOptionNames = state.globalOptionNames.filter { it in state.options },
             templates = templates,
             agents = pi.agents,
-            metadata = pi.root?.let { PiParser.parseMetadata(it, text) } ?: ProjectMetadata(),
+            metadata = pi.root?.let {
+                PiParser.parseMetadata(INTERFACE_JSON, it, text, diagnostics)
+            } ?: ProjectMetadata(),
             telemetry = pi.root?.let(PiParser::parseTelemetry),
             translations = translations,
         )

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
@@ -49,8 +49,8 @@ data class SessionUiState(
     /** PI 版本是开发态：设置页不展示开关；上报仍由 TelemetryController 拦截 */
     val telemetryLockedByVersion: Boolean = false,
     val telemetryEnabled: Boolean = false,
-    /** 非 null = 这份 welcome 还没给用户看过 */
-    val welcomePrompt: String? = null,
+    /** 非 null = 这份有序 welcome 列表还没给用户看过 */
+    val welcomePrompt: List<String>? = null,
     val environment: ResolvedEnvironment? = null,
     val sessionDiagnostics: List<Diagnostic> = emptyList(),
     val runner: RunnerState = RunnerState(),

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -288,7 +288,9 @@ class SessionViewModel(
             telemetryDeclared = project.definition.telemetry != null,
             telemetryLockedByVersion = isDebugProjectVersion(project.definition.version),
             welcomePrompt = metadata.welcome
-                ?.takeIf { metadata.welcomeFingerprint != config.welcomeFingerprint },
+                .takeIf {
+                    it.isNotEmpty() && metadata.welcomeFingerprint != config.welcomeFingerprint
+                },
             configurationList = session.configurationList,
             activeConfiguration = session.activeConfiguration,
             taskCatalog = session.taskCatalog,

--- a/app/src/main/java/com/aliothmoon/maafw/ui/AppRoot.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/AppRoot.kt
@@ -326,7 +326,7 @@ fun AppRoot(
 
         MaaMarkdownSheet(
             title = stringResource(R.string.welcome_title),
-            body = state.welcomePrompt,
+            bodies = state.welcomePrompt,
             onDismiss = { viewModel.onIntent(SessionIntent.DismissWelcome) },
         )
 

--- a/app/src/main/java/com/aliothmoon/maafw/ui/components/MaaMarkdownSheet.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/components/MaaMarkdownSheet.kt
@@ -16,7 +16,16 @@ fun MaaMarkdownSheet(
     body: String?,
     onDismiss: () -> Unit,
 ) {
-    if (body == null) return
+    MaaMarkdownSheet(title, body?.let(::listOf), onDismiss)
+}
+
+@Composable
+fun MaaMarkdownSheet(
+    title: String,
+    bodies: List<String>?,
+    onDismiss: () -> Unit,
+) {
+    if (bodies.isNullOrEmpty()) return
     MaaModalSheet(onDismiss = onDismiss) { modifier ->
         Column(modifier) {
             MaaSheetHeader(title = title, onClose = onDismiss)
@@ -26,11 +35,18 @@ fun MaaMarkdownSheet(
                     .verticalScroll(rememberScrollState())
                     .padding(bottom = MaaDesignTokens.Spacing.lg),
             ) {
-                MaaMarkdown(
-                    text = body,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                bodies.forEachIndexed { index, body ->
+                    MaaMarkdown(
+                        text = body,
+                        modifier = if (index == 0) {
+                            Modifier
+                        } else {
+                            Modifier.padding(top = MaaDesignTokens.Spacing.md)
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -529,6 +529,7 @@
     <string name="diagnostic_resource_path_missing">Resource "%1$s" is missing path</string>
     <string name="diagnostic_no_adb_controller">This project declares no Adb controller; tasks restricted to a controller are unavailable</string>
     <string name="diagnostic_language_path_invalid">Language "%1$s" path is not a string</string>
+    <string name="diagnostic_welcome_invalid">welcome must be a non-empty string or a non-empty string array; ignored</string>
     <string name="diagnostic_import_read_failed">Failed to read import; skipped: %1$s</string>
     <string name="diagnostic_project_has_no_tasks">Project declares no tasks</string>
     <string name="diagnostic_duplicate_declaration">Duplicate %1$s "%2$s"; keeping the first declaration</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,6 +520,7 @@
     <string name="diagnostic_resource_path_missing">resource "%1$s" 缺少 path</string>
     <string name="diagnostic_no_adb_controller">该项目未声明 Adb controller，限定 controller 的任务都不可用</string>
     <string name="diagnostic_language_path_invalid">languages "%1$s" 的路径不是字符串</string>
+    <string name="diagnostic_welcome_invalid">welcome 必须是非空字符串或非空字符串数组，已忽略</string>
     <string name="diagnostic_import_read_failed">import 分片读取失败，已跳过：%1$s</string>
     <string name="diagnostic_project_has_no_tasks">项目未声明任何任务</string>
     <string name="diagnostic_duplicate_declaration">%1$s "%2$s" 重复声明，保留先出现的定义</string>

--- a/app/src/test/java/com/aliothmoon/maafw/project/PiMetadataTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/project/PiMetadataTest.kt
@@ -1,6 +1,10 @@
 package com.aliothmoon.maafw.project
 
+import com.aliothmoon.maafw.R
+import com.aliothmoon.maafw.domain.Diagnostic
+import com.aliothmoon.maafw.domain.DiagnosticSeverity
 import com.aliothmoon.maafw.domain.OptionDefinition
+import com.aliothmoon.maafw.i18n.isResource
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
@@ -38,7 +42,7 @@ class PiMetadataTest {
             MapTextResolver(mapOf("welcome.body" to "欢迎使用")),
         )
 
-        assertEquals("欢迎使用", metadata.welcome)
+        assertEquals(listOf("欢迎使用"), metadata.welcome)
         assertEquals("一句话说明", metadata.description)
         assertEquals("CONTACT", metadata.contact)
         assertEquals("https://example.com/owner/repo", metadata.github)
@@ -52,6 +56,29 @@ class PiMetadataTest {
         )
         assertNull(metadata.github)
         assertNull(metadata.githubRepository)
+    }
+
+    @Test
+    fun `welcome 数组按声明顺序物化且保留 URL`() {
+        val metadata = PiParser.parseMetadata(
+            root(
+                """
+                {
+                  "welcome": [
+                    "${'$'}welcome.first",
+                    "announcements/update.md",
+                    "https://example.com/announcement.md"
+                  ]
+                }
+                """.trimIndent(),
+            ),
+            MapTextResolver(mapOf("welcome.first" to "第一条公告")),
+        )
+
+        assertEquals(
+            listOf("第一条公告", "announcements/update.md", "https://example.com/announcement.md"),
+            metadata.welcome,
+        )
     }
 
     @Test
@@ -86,6 +113,32 @@ class PiMetadataTest {
     }
 
     @Test
+    fun `单字符串与单元素数组指纹相同`() {
+        val text = MapTextResolver(emptyMap())
+        val scalar = PiParser.parseMetadata(root("""{ "welcome": "hi" }"""), text)
+        val array = PiParser.parseMetadata(root("""{ "welcome": ["hi"] }"""), text)
+
+        assertEquals(scalar.welcome, array.welcome)
+        assertEquals(scalar.welcomeFingerprint, array.welcomeFingerprint)
+    }
+
+    @Test
+    fun `公告列表变化时指纹跟着变`() {
+        val text = MapTextResolver(emptyMap())
+
+        fun fingerprint(welcome: String): String? = PiParser.parseMetadata(
+            root("""{ "version": "1.0.0", "welcome": $welcome }"""),
+            text,
+        ).welcomeFingerprint
+
+        val baseline = fingerprint("""["a","b"]""")
+        assertNotEquals(baseline, fingerprint("""["a"]"""))
+        assertNotEquals(baseline, fingerprint("""["a","c"]"""))
+        assertNotEquals(baseline, fingerprint("""["b","a"]"""))
+        assertNotEquals(baseline, fingerprint("""["a","b","c"]"""))
+    }
+
+    @Test
     fun `PI 版本变化时指纹跟着变`() {
         val text = MapTextResolver(emptyMap())
         val v1 = PiParser.parseMetadata(root("""{ "version": "1.0.0", "welcome": "hi" }"""), text)
@@ -96,8 +149,37 @@ class PiMetadataTest {
     @Test
     fun `没有 welcome 就没有指纹`() {
         val metadata = PiParser.parseMetadata(root("""{ "name": "x" }"""), MapTextResolver(emptyMap()))
-        assertNull(metadata.welcome)
+        assertTrue(metadata.welcome.isEmpty())
         assertNull(metadata.welcomeFingerprint)
+    }
+
+    @Test
+    fun `非法 welcome 记 Error 且不生成指纹`() {
+        listOf(
+            """{ "welcome": [] }""",
+            """{ "welcome": ["ok", 3] }""",
+            """{ "welcome": {} }""",
+            """{ "welcome": null }""",
+            """{ "welcome": 3 }""",
+            """{ "welcome": true }""",
+        ).forEach { json ->
+            val diagnostics = mutableListOf<Diagnostic>()
+            val metadata = PiParser.parseMetadata(
+                "interface.json",
+                root(json),
+                MapTextResolver(emptyMap()),
+                diagnostics,
+            )
+
+            assertTrue(metadata.welcome.isEmpty())
+            assertNull(metadata.welcomeFingerprint)
+            assertTrue(
+                diagnostics.any {
+                    it.severity == DiagnosticSeverity.Error &&
+                        it.message.isResource(R.string.diagnostic_welcome_invalid)
+                },
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/aliothmoon/maafw/project/ProjectLoaderTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/project/ProjectLoaderTest.kt
@@ -654,6 +654,84 @@ class ProjectLoaderControllerTest {
     }
 }
 
+class ProjectLoaderWelcomeTest {
+
+    private fun load(files: Map<String, String>): ProjectLoadResult.Ready {
+        val result = ProjectLoader(MapProjectSource(files)).load()
+        assertTrue("加载应成功: $result", result is ProjectLoadResult.Ready)
+        return result as ProjectLoadResult.Ready
+    }
+
+    @Test
+    fun `welcome 数组按顺序读取文件并保留 URL`() {
+        val ready = load(
+            mapOf(
+                "interface.json" to piRoot(
+                    "tasks/a.json",
+                    body = """
+                        "welcome": [
+                            "announcements/first.md",
+                            "announcements/second.md",
+                            "https://example.com/announcement.md"
+                        ]
+                    """.trimIndent(),
+                ),
+                "tasks/a.json" to """{"task":[{"name":"T1","entry":"E1"}]}""",
+                "announcements/first.md" to "# First",
+                "announcements/second.md" to "# Second",
+            ),
+        )
+
+        assertEquals(
+            listOf("# First", "# Second", "https://example.com/announcement.md"),
+            ready.definition.metadata.welcome,
+        )
+    }
+
+    @Test
+    fun `welcome 文件读取失败保留原始路径并记 warning`() {
+        val ready = load(
+            mapOf(
+                "interface.json" to piRoot(
+                    "tasks/a.json",
+                    body = """"welcome":["missing.md","announcements/second.md"]""",
+                ),
+                "tasks/a.json" to """{"task":[{"name":"T1","entry":"E1"}]}""",
+                "announcements/second.md" to "# Second",
+            ),
+        )
+
+        assertEquals(listOf("missing.md", "# Second"), ready.definition.metadata.welcome)
+        assertTrue(
+            ready.diagnostics.any {
+                it.severity == DiagnosticSeverity.Warning &&
+                    it.message.isResource(
+                        R.string.diagnostic_description_read_failed,
+                        "no file: missing.md",
+                    )
+            },
+        )
+    }
+
+    @Test
+    fun `welcome 非法声明记 Error`() {
+        val ready = load(
+            mapOf(
+                "interface.json" to piRoot("tasks/a.json", body = """"welcome":[]"""),
+                "tasks/a.json" to """{"task":[{"name":"T1","entry":"E1"}]}""",
+            ),
+        )
+
+        assertTrue(ready.definition.metadata.welcome.isEmpty())
+        assertTrue(
+            ready.diagnostics.any {
+                it.severity == DiagnosticSeverity.Error &&
+                    it.message.isResource(R.string.diagnostic_welcome_invalid)
+            },
+        )
+    }
+}
+
 class ProjectLoaderAgentTest {
 
     private fun load(files: Map<String, String>): ProjectLoadResult.Ready {

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -6,6 +6,7 @@ import com.aliothmoon.maafw.constant.AppPaths
 import com.aliothmoon.maafw.domain.ConfiguredTask
 import com.aliothmoon.maafw.domain.ControllerDefinition
 import com.aliothmoon.maafw.domain.ProjectDefinition
+import com.aliothmoon.maafw.domain.ProjectMetadata
 import com.aliothmoon.maafw.domain.ResourceDefinition
 import com.aliothmoon.maafw.domain.RunConfiguration
 import com.aliothmoon.maafw.domain.RunConfigurationId
@@ -75,6 +76,7 @@ import kotlin.io.path.createTempDirectory
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -280,6 +282,28 @@ class SessionViewModelTest {
             ),
             preview.touches,
         )
+    }
+
+    @Test
+    fun `welcome list prompts once and stores the list fingerprint`() = runTest(mainDispatcher) {
+        val metadataDefinition = definition.copy(
+            metadata = ProjectMetadata(
+                welcome = listOf("# First", "# Second"),
+                welcomeFingerprint = "list-fingerprint",
+            ),
+        )
+        val project = FakeProjectRepository(ProjectState.Ready(metadataDefinition, emptyList()))
+        val store = readyStore()
+        val (vm, _, _) = createVm(store = store, project = project)
+        advanceUntilIdle()
+
+        assertEquals(listOf("# First", "# Second"), vm.uiState.value.welcomePrompt)
+
+        vm.onIntent(SessionIntent.DismissWelcome)
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.welcomePrompt)
+        assertEquals("list-fingerprint", store.current.welcomeFingerprint)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 支持 PI v2.10.2 将 welcome 声明为有序字符串数组，并保留单字符串兼容
- 按声明顺序物化和展示多条公告，非法 welcome 会记录诊断并忽略
- 指纹基于完整原始有序声明计算，单元素数组沿用旧指纹，避免重复弹窗

## Test
- ./gradlew :app:testDebugUnitTest --rerun-tasks