### PR TITLE
feat: 支持虚拟屏导航按键

### DIFF
--- a/app/src/main/aidl/com/aliothmoon/maafw/RemoteService.aidl
+++ b/app/src/main/aidl/com/aliothmoon/maafw/RemoteService.aidl
@@ -41,6 +41,9 @@ interface RemoteService {
 
     void stopVirtualDisplay() = 13;
 
+    /** 后台虚拟屏是否仍存在；任务结束不等于虚拟屏结束 */
+    boolean isVirtualDisplayRunning() = 37;
+
     boolean isAppOnVirtualDisplay(String packageName) = 14;
 
     boolean moveAppToVirtualDisplay(String packageName) = 15;
@@ -74,6 +77,9 @@ interface RemoteService {
     oneway void touchMove(int x, int y, int contact) = 34;
 
     oneway void touchUp(int x, int y, int contact) = 35;
+
+    /** 只注入后台虚拟屏；主屏模式或没有虚拟屏时忽略 */
+    oneway void pressKey(int keyCode) = 36;
 
     // ── 代授权限 ──
 

--- a/app/src/main/java/com/aliothmoon/maafw/bridge/InputControlUtils.java
+++ b/app/src/main/java/com/aliothmoon/maafw/bridge/InputControlUtils.java
@@ -194,24 +194,57 @@ public final class InputControlUtils {
         return apply(TouchPointerSequence.Kind.Up, x, y, contact, displayId);
     }
 
-    public static boolean keyDown(int keyCode, int displayId) {
-        long downTime = SystemClock.uptimeMillis();
-        KeyEvent keyEvent = new KeyEvent(downTime, downTime, KeyEvent.ACTION_DOWN, keyCode, 0);
+    private static KeyEvent obtainKeyEvent(long downTime, long eventTime, int action, int keyCode) {
+        return new KeyEvent(
+                downTime,
+                eventTime,
+                action,
+                keyCode,
+                0,
+                0,
+                DEFAULT_DEVICE_ID,
+                0,
+                0,
+                InputDevice.SOURCE_KEYBOARD
+        );
+    }
 
+    private static boolean injectKey(KeyEvent keyEvent, int displayId, int injectMode) {
         if (!setDisplayId(keyEvent, displayId)) {
             return false;
         }
-        return getManager().injectInputEvent(keyEvent, InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH);
+        return getManager().injectInputEvent(keyEvent, injectMode);
+    }
+
+    public static boolean keyDown(int keyCode, int displayId) {
+        long downTime = SystemClock.uptimeMillis();
+        return injectKey(
+                obtainKeyEvent(downTime, downTime, KeyEvent.ACTION_DOWN, keyCode),
+                displayId,
+                InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH);
     }
 
     public static boolean keyUp(int keyCode, int displayId) {
         long upTime = SystemClock.uptimeMillis();
-        KeyEvent keyEvent = new KeyEvent(upTime, upTime, KeyEvent.ACTION_UP, keyCode, 0);
+        return injectKey(
+                obtainKeyEvent(upTime, upTime, KeyEvent.ACTION_UP, keyCode),
+                displayId,
+                InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+    }
 
-        if (!setDisplayId(keyEvent, displayId)) {
-            return false;
-        }
-
-        return getManager().injectInputEvent(keyEvent, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+    /**
+     * 成对注入一次按键；UP 使用与 DOWN 相同的 downTime，确保系统按同一次按压处理
+     */
+    public static boolean pressKey(int keyCode, int displayId) {
+        long downTime = SystemClock.uptimeMillis();
+        boolean down = injectKey(
+                obtainKeyEvent(downTime, downTime, KeyEvent.ACTION_DOWN, keyCode),
+                displayId,
+                InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH);
+        boolean up = injectKey(
+                obtainKeyEvent(downTime, SystemClock.uptimeMillis(), KeyEvent.ACTION_UP, keyCode),
+                displayId,
+                InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+        return down && up;
     }
 }

--- a/app/src/main/java/com/aliothmoon/maafw/remote/RemoteServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/RemoteServiceImpl.kt
@@ -190,6 +190,10 @@ class RemoteServiceImpl : RemoteService.Stub() {
         }
     }
 
+    override fun isVirtualDisplayRunning(): Boolean =
+        virtualDisplayMode.get() == DisplayMode.BACKGROUND &&
+            VirtualDisplayManager.getDisplayId() != DefaultDisplayConfig.DISPLAY_NONE
+
     /** 没有虚拟屏时返回 true：调用方据此判断「是否需要拉回」，无屏可拉即无需处理 */
     override fun isAppOnVirtualDisplay(packageName: String): Boolean {
         val displayId = VirtualDisplayManager.getDisplayId()
@@ -254,6 +258,9 @@ class RemoteServiceImpl : RemoteService.Stub() {
 
     override fun touchUp(x: Int, y: Int, contact: Int) =
         withVirtualDisplay { InputControlUtils.up(x, y, contact, it) }
+
+    override fun pressKey(keyCode: Int) =
+        withVirtualDisplay { InputControlUtils.pressKey(keyCode, it) }
 
     private inline fun withVirtualDisplay(action: (Int) -> Unit) {
         if (virtualDisplayMode.get() == DisplayMode.PRIMARY) return

--- a/app/src/main/java/com/aliothmoon/maafw/runner/PreviewPort.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/PreviewPort.kt
@@ -1,6 +1,7 @@
 package com.aliothmoon.maafw.runner
 
 import android.os.SystemClock
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.Surface
 import com.aliothmoon.maafw.ITouchEventCallback
@@ -21,6 +22,13 @@ import java.util.concurrent.atomic.AtomicReference
 
 /** 与特权侧 `TouchPointerSequence.MAX_CONTACTS` 同值；校验在那边做，这里只是不把依赖伸进 bridge */
 const val MAX_PREVIEW_CONTACTS = 16
+
+/** 可注入虚拟屏的 Android 系统主按键 */
+enum class VirtualDisplayKey(val keyCode: Int) {
+    Back(KeyEvent.KEYCODE_BACK),
+    Home(KeyEvent.KEYCODE_HOME),
+    Recents(KeyEvent.KEYCODE_APP_SWITCH),
+}
 
 /**
  * 预览上的一次触点，坐标在虚拟屏坐标系
@@ -63,6 +71,9 @@ interface PreviewPort {
     fun touchDown(x: Int, y: Int, contact: Int)
     fun touchMove(x: Int, y: Int, contact: Int)
     fun touchUp(x: Int, y: Int, contact: Int)
+
+    /** 向虚拟屏注入一次系统主按键 */
+    fun pressKey(key: VirtualDisplayKey)
 }
 
 /**
@@ -142,7 +153,9 @@ class RemotePreviewPort(
 
     override fun touchUp(x: Int, y: Int, contact: Int) = withService { it.touchUp(x, y, contact) }
 
-    /** 手动触摸是 oneway，发不出去就算了；预览本来就是尽力而为 */
+    override fun pressKey(key: VirtualDisplayKey) = withService { it.pressKey(key.keyCode) }
+
+    /** 手动输入是 oneway，发不出去就算了；预览本来就是尽力而为 */
     private inline fun withService(action: (RemoteService) -> Unit) {
         val service = servicePort.serviceOrNull() ?: return
         runCatching { action(service) }.onFailure { Timber.w(it, "Preview touch failed") }

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionContracts.kt
@@ -29,6 +29,7 @@ import com.aliothmoon.maafw.runner.DisplayResolution
 import com.aliothmoon.maafw.runner.ResolutionPreference
 import com.aliothmoon.maafw.runner.RunnerPhase
 import com.aliothmoon.maafw.runner.RunnerState
+import com.aliothmoon.maafw.runner.VirtualDisplayKey
 import com.aliothmoon.maafw.runner.isBusy
 
 /** 跨页工作会话聚合态；Activity 作用域单实例，UI 只读 */
@@ -74,6 +75,10 @@ data class SessionUiState(
     val previewResolution: DisplayResolution? = null,
     /** 目标 app 在虚拟屏上的看门狗状态；预览小窗右上角徽标用它（AppWatchdog） */
     val watchdogState: WatchdogState = WatchdogState.IDLE,
+    /** 后台虚拟屏是否仍存在；任务结束不等于虚拟屏结束 */
+    val virtualDisplayRunning: Boolean = false,
+    /** 虚拟屏按键操作锁；只保存在当前进程，不持久化到下次启动 */
+    val virtualDisplayKeysUnlocked: Boolean = false,
     val remoteAccess: RemoteAccessState = RemoteAccessState(),
     /** 授权请求进行中；只压按钮，不进 configurationLocked */
     val remoteAccessGranting: Boolean = false,
@@ -86,6 +91,14 @@ data class SessionUiState(
 
     val privilegedServiceConnected: Boolean
         get() = privilegedService == PrivilegedServiceState.Connected
+
+    /** 原本的可用条件：只服务后台虚拟屏，且必须仍能通过特权进程注入 */
+    val virtualDisplayKeysAvailable: Boolean
+        get() = runMode == RunMode.BACKGROUND && virtualDisplayRunning && privilegedServiceConnected
+
+    /** 三个系统主按键还要通过用户显式解锁 */
+    val virtualDisplayKeysEnabled: Boolean
+        get() = virtualDisplayKeysAvailable && virtualDisplayKeysUnlocked
 
     /**
      * 首页那一行服务状态：连接态、项目加载、运行态三路归约成一句
@@ -318,6 +331,12 @@ sealed interface SessionIntent {
         val action: PreviewTouchAction,
         val contact: Int,
     ) : SessionIntent
+
+    /** 向后台虚拟屏注入 Android 系统主按键 */
+    data class PressVirtualDisplayKey(val key: VirtualDisplayKey) : SessionIntent
+
+    /** 当前进程内临时解锁虚拟屏按键；不写设置，下次启动恢复锁定 */
+    data class SetVirtualDisplayKeysUnlocked(val unlocked: Boolean) : SessionIntent
 
     /** 向当前后端发起授权；不走 guarded，运行中也允许（授权不改配置） */
     data object RequestRemoteAccess : SessionIntent

--- a/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/session/SessionViewModel.kt
@@ -57,14 +57,18 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /** app 设置的一次快照；combine 的元数上限是 5，几项设置得先并成一个 */
@@ -130,6 +134,9 @@ class SessionViewModel(
         PrivilegedSnapshot(access, granting, readiness, service, system)
     }
 
+    private val _virtualDisplayRunning = MutableStateFlow(false)
+    private val _virtualDisplayKeysUnlocked = MutableStateFlow(false)
+
     private val settingsState: Flow<SettingsSnapshot> = combine(
         appSettings.runMode,
         appSettings.overlayControlMode,
@@ -164,6 +171,10 @@ class SessionViewModel(
     }.flowOn(MaaDispatchers.Default) // resolve 属重计算，不占用主线程
         .combine(permissionGateway.watchdogState) { base, wd -> base.copy(watchdogState = wd) }
         .combine(piInstall.state) { base, install -> base.copy(piInstallState = install) }
+        .combine(_virtualDisplayRunning) { base, running -> base.copy(virtualDisplayRunning = running) }
+        .combine(_virtualDisplayKeysUnlocked) { base, unlocked ->
+            base.copy(virtualDisplayKeysUnlocked = unlocked)
+        }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
@@ -218,6 +229,20 @@ class SessionViewModel(
                         }
                     }
                 }
+        }
+        viewModelScope.launch {
+            permissionGateway.serviceState.collect { state ->
+                if (state == PrivilegedServiceState.Connected) {
+                    refreshVirtualDisplayRunning()
+                } else {
+                    _virtualDisplayRunning.value = false
+                }
+            }
+        }
+        viewModelScope.launch {
+            runnerPort.state.map { it.phase }.distinctUntilChanged().collect {
+                refreshVirtualDisplayRunning()
+            }
         }
     }
 
@@ -491,9 +516,12 @@ class SessionViewModel(
             SessionIntent.ShowScreenSaver -> emitEffect(SessionEffect.ShowScreenSaver)
             // 关目标应用即停虚拟屏：屏没了应用跟着退，不必让 app 侧知道包名
             // serviceOrNull 而不是 useService：一颗次级按钮，不值得为它弹授权请求
-            SessionIntent.CloseTargetApp -> servicePort.serviceOrNull()?.let { service ->
-                runCatching { service.stopVirtualDisplay() }
-                    .onFailure { Timber.w(it, "stopVirtualDisplay failed") }
+            SessionIntent.CloseTargetApp -> {
+                servicePort.serviceOrNull()?.let { service ->
+                    runCatching { service.stopVirtualDisplay() }
+                        .onFailure { Timber.w(it, "stopVirtualDisplay failed") }
+                }
+                refreshVirtualDisplayRunning()
             }
 
             // 语言切换会触发 PI 重载（翻译加载期物化），运行中同样拦截
@@ -530,6 +558,11 @@ class SessionViewModel(
                 PreviewTouchAction.Up -> previewPort.touchUp(intent.x, intent.y, intent.contact)
             }
 
+            is SessionIntent.PressVirtualDisplayKey -> previewPort.pressKey(intent.key)
+
+            is SessionIntent.SetVirtualDisplayKeysUnlocked ->
+                _virtualDisplayKeysUnlocked.value = intent.unlocked
+
             // 提权一律不走 guarded：它不改 UserConfiguration，运行中断了连也得能重授
             SessionIntent.RequestRemoteAccess -> permissionGateway.requestRemoteAccess()
             SessionIntent.TogglePrivilegedService -> togglePrivilegedService()
@@ -554,6 +587,13 @@ class SessionViewModel(
     }
 
     private fun locked(): Boolean = runnerPort.state.value.phase.isBusy
+
+    private suspend fun refreshVirtualDisplayRunning() {
+        _virtualDisplayRunning.value = withContext(MaaDispatchers.IO) {
+            runCatching { servicePort.serviceOrNull()?.isVirtualDisplayRunning() == true }
+                .getOrDefault(false)
+        }
+    }
 
     private suspend fun appendAndActivate(configuration: RunConfiguration) {
         configurationStore.update { config ->

--- a/app/src/main/java/com/aliothmoon/maafw/theme/MaaIcons.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/theme/MaaIcons.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
+import androidx.compose.material.icons.automirrored.outlined.Undo
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
@@ -171,6 +172,9 @@ object MaaIcons {
 
     val ArrowBackFilled: ImageVector
         @Composable get() = themed(SemiIconRes.Mono.arrow_left, Icons.AutoMirrored.Filled.ArrowBack)
+
+    val BackAction: ImageVector
+        @Composable get() = themed(SemiIconRes.Mono.undo, Icons.AutoMirrored.Outlined.Undo)
 
     val CaretDown: ImageVector
         @Composable get() = themed(SemiIconRes.Mono.caretdown, Icons.Outlined.ArrowDropDown)

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksRunnerBar.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksRunnerBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.ExitToApp
 import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.Cancel
@@ -34,7 +33,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -55,10 +53,12 @@ import com.aliothmoon.maafw.runner.VirtualDisplayKey
 import com.aliothmoon.maafw.session.SessionIntent
 import com.aliothmoon.maafw.session.SessionUiState
 import com.aliothmoon.maafw.theme.MaaDesignTokens
+import com.aliothmoon.maafw.theme.MaaIcons
+import com.aliothmoon.maafw.theme.MaaTheme
 import com.aliothmoon.maafw.ui.components.MaaButton
 import com.aliothmoon.maafw.ui.components.MaaOutlinedButton
 import com.aliothmoon.maafw.ui.components.MaaSemanticOutlinedButton
-import com.aliothmoon.maafw.theme.MaaTheme
+import com.aliothmoon.maafw.ui.components.MaaSwitch
 
 /**
  * 底部启停条
@@ -273,7 +273,7 @@ internal fun TasksQuickOptionsPanel(
                             style = MaterialTheme.typography.bodyMedium,
                             modifier = Modifier.weight(1f),
                         )
-                        Switch(
+                        MaaSwitch(
                             checked = state.virtualDisplayKeysUnlocked,
                             onCheckedChange = {
                                 onIntent(SessionIntent.SetVirtualDisplayKeysUnlocked(it))
@@ -290,7 +290,7 @@ internal fun TasksQuickOptionsPanel(
                         horizontalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.sm),
                     ) {
                         ActionIconTile(
-                            icon = Icons.AutoMirrored.Outlined.ArrowBack,
+                            icon = MaaIcons.BackAction,
                             contentDescription = stringResource(R.string.quick_action_back),
                             accent = MaterialTheme.colorScheme.secondary,
                             enabled = state.virtualDisplayKeysEnabled,

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksRunnerBar.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksRunnerBar.kt
@@ -15,9 +15,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.ExitToApp
+import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.Cancel
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Layers
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.LockOpen
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Nightlight
 import androidx.compose.material.icons.outlined.PowerSettingsNew
@@ -29,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -45,6 +51,7 @@ import com.aliothmoon.maafw.R
 import com.aliothmoon.maafw.domain.RunMode
 import com.aliothmoon.maafw.runner.RunnerPhase
 import com.aliothmoon.maafw.runner.isBusy
+import com.aliothmoon.maafw.runner.VirtualDisplayKey
 import com.aliothmoon.maafw.session.SessionIntent
 import com.aliothmoon.maafw.session.SessionUiState
 import com.aliothmoon.maafw.theme.MaaDesignTokens
@@ -229,6 +236,92 @@ internal fun TasksQuickOptionsPanel(
                     modifier = Modifier.fillMaxWidth(),
                 )
 
+                if (state.runMode == RunMode.BACKGROUND) {
+                    GroupLabel(stringResource(R.string.virtual_display_keys_title))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                onIntent(
+                                    SessionIntent.SetVirtualDisplayKeysUnlocked(
+                                        !state.virtualDisplayKeysUnlocked,
+                                    ),
+                                )
+                            }
+                            .padding(vertical = MaaDesignTokens.Spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.md),
+                    ) {
+                        Icon(
+                            imageVector = if (state.virtualDisplayKeysUnlocked) {
+                                Icons.Outlined.LockOpen
+                            } else {
+                                Icons.Outlined.Lock
+                            },
+                            contentDescription = null,
+                            modifier = Modifier.size(MaaDesignTokens.IconSize.sm),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = stringResource(
+                                if (state.virtualDisplayKeysUnlocked) {
+                                    R.string.virtual_display_keys_unlocked
+                                } else {
+                                    R.string.virtual_display_keys_locked
+                                },
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Switch(
+                            checked = state.virtualDisplayKeysUnlocked,
+                            onCheckedChange = {
+                                onIntent(SessionIntent.SetVirtualDisplayKeysUnlocked(it))
+                            },
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.virtual_display_keys_warning),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.sm),
+                    ) {
+                        ActionIconTile(
+                            icon = Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = stringResource(R.string.quick_action_back),
+                            accent = MaterialTheme.colorScheme.secondary,
+                            enabled = state.virtualDisplayKeysEnabled,
+                            onClick = {
+                                onIntent(SessionIntent.PressVirtualDisplayKey(VirtualDisplayKey.Back))
+                            },
+                            modifier = Modifier.weight(1f),
+                        )
+                        ActionIconTile(
+                            icon = Icons.Outlined.Home,
+                            contentDescription = stringResource(R.string.quick_action_home),
+                            accent = MaterialTheme.colorScheme.secondary,
+                            enabled = state.virtualDisplayKeysEnabled,
+                            onClick = {
+                                onIntent(SessionIntent.PressVirtualDisplayKey(VirtualDisplayKey.Home))
+                            },
+                            modifier = Modifier.weight(1f),
+                        )
+                        ActionIconTile(
+                            icon = Icons.Outlined.Apps,
+                            contentDescription = stringResource(R.string.quick_action_recents),
+                            accent = MaterialTheme.colorScheme.secondary,
+                            enabled = state.virtualDisplayKeysEnabled,
+                            onClick = {
+                                onIntent(SessionIntent.PressVirtualDisplayKey(VirtualDisplayKey.Recents))
+                            },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+
                 GroupLabel(stringResource(R.string.quick_settings_title))
                 if (state.runMode == RunMode.BACKGROUND) {
                     SettingToggleRow(
@@ -270,6 +363,40 @@ private val PanelBottomInset = 56.dp
 
 /** 动作块高度；比一行文字略高，两块并排时才不显得挤 */
 private val ActionTileHeight = 36.dp
+
+/** 图标动作块：没有可见文字时用 contentDescription 保留无障碍语义 */
+@Composable
+private fun ActionIconTile(
+    icon: ImageVector,
+    contentDescription: String,
+    accent: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    val tint = if (enabled) accent else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier.height(ActionTileHeight),
+        shape = RoundedCornerShape(MaaTheme.style.radii.inner),
+        color = tint.copy(alpha = 0.08f),
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        border = BorderStroke(MaaDesignTokens.Separator.thickness, tint.copy(alpha = 0.2f)),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(MaaDesignTokens.IconSize.sm),
+                tint = tint,
+            )
+        }
+    }
+}
 
 /**
  * 一格动作：底色与描边都从 accent 派生

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -392,6 +392,13 @@
     <string name="quick_settings_title">Automation</string>
     <string name="quick_action_screen_saver">Screen off</string>
     <string name="quick_action_close_app">Close target app</string>
+    <string name="quick_action_back">Back</string>
+    <string name="quick_action_home">Home</string>
+    <string name="quick_action_recents">Recents</string>
+    <string name="virtual_display_keys_title">Virtual display keys</string>
+    <string name="virtual_display_keys_locked">Button controls locked</string>
+    <string name="virtual_display_keys_unlocked">Button controls unlocked</string>
+    <string name="virtual_display_keys_warning">Using these buttons may disrupt the task flow</string>
     <string name="quick_setting_close_app_after_task">Close the target app when task ends</string>
     <string name="quick_setting_touch_preview">Show touch preview</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,13 @@
     <string name="quick_settings_title">自动设置</string>
     <string name="quick_action_screen_saver">熄屏挂机</string>
     <string name="quick_action_close_app">关闭目标应用</string>
+    <string name="quick_action_back">返回</string>
+    <string name="quick_action_home">主页</string>
+    <string name="quick_action_recents">最近任务</string>
+    <string name="virtual_display_keys_title">虚拟屏按键</string>
+    <string name="virtual_display_keys_locked">按键操作已锁定</string>
+    <string name="virtual_display_keys_unlocked">按键操作已解锁</string>
+    <string name="virtual_display_keys_warning">使用按钮操作可能破坏任务流程</string>
     <string name="quick_setting_close_app_after_task">任务自动结束时关闭目标应用</string>
     <string name="quick_setting_touch_preview">显示触摸预览</string>
 

--- a/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
@@ -31,6 +31,9 @@ open class FakePrivilegedService : RemoteService {
         private set
     var stopTargetAppCount: Int = 0
         private set
+    var virtualDisplayRunning: Boolean = false
+
+    val pressedKeys: MutableList<Int> = mutableListOf()
 
     var runnerCallback: IMaaRunnerCallback? = null
         private set
@@ -72,7 +75,10 @@ open class FakePrivilegedService : RemoteService {
     override fun setVirtualDisplayMode(mode: Int): Boolean = true
     override fun setVirtualDisplayResolution(width: Int, height: Int, dpi: Int) = Unit
     override fun startVirtualDisplay(): Int = 1
-    override fun stopVirtualDisplay() = Unit
+    override fun stopVirtualDisplay() {
+        virtualDisplayRunning = false
+    }
+    override fun isVirtualDisplayRunning(): Boolean = virtualDisplayRunning
     override fun isAppOnVirtualDisplay(packageName: String?): Boolean = true
     override fun moveAppToVirtualDisplay(packageName: String?): Boolean = true
     override fun setForceFullscreenOnVirtualDisplay(enabled: Boolean) = Unit
@@ -84,6 +90,9 @@ open class FakePrivilegedService : RemoteService {
     override fun touchDown(x: Int, y: Int, contact: Int) = Unit
     override fun touchMove(x: Int, y: Int, contact: Int) = Unit
     override fun touchUp(x: Int, y: Int, contact: Int) = Unit
+    override fun pressKey(keyCode: Int) {
+        pressedKeys += keyCode
+    }
     override fun grantPermissions(packageName: String?, uid: Int, permissions: Int): Int = permissions
     override fun isPackageInstalled(packageName: String?): Boolean = true
     override fun setRunnerCallback(callback: IMaaRunnerCallback?) {

--- a/app/src/test/java/com/aliothmoon/maafw/runner/RecordingPreviewPort.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/RecordingPreviewPort.kt
@@ -37,4 +37,10 @@ class RecordingPreviewPort : PreviewPort {
     override fun touchUp(x: Int, y: Int, contact: Int) {
         touches += Touch(x, y, "up", contact)
     }
+
+    val keys = mutableListOf<VirtualDisplayKey>()
+
+    override fun pressKey(key: VirtualDisplayKey) {
+        keys += key
+    }
 }

--- a/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/session/SessionViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.aliothmoon.maafw.session
 
+import android.view.KeyEvent
 import com.aliothmoon.maafw.MaaDispatchers
 import com.aliothmoon.maafw.config.InMemoryUserConfigurationStore
 import com.aliothmoon.maafw.constant.AppPaths
@@ -19,6 +20,7 @@ import com.aliothmoon.maafw.i18n.AppLocales
 import com.aliothmoon.maafw.i18n.isResource
 import com.aliothmoon.maafw.privileged.FakeDisplaySizeGateway
 import com.aliothmoon.maafw.privileged.FakePermissionGateway
+import com.aliothmoon.maafw.privileged.FakePrivilegedService
 import com.aliothmoon.maafw.privileged.FakePrivilegedServicePort
 import com.aliothmoon.maafw.privileged.PrivilegedServiceState
 import com.aliothmoon.maafw.settings.FakeAppSettingsGateway
@@ -51,6 +53,7 @@ import com.aliothmoon.maafw.runner.RunnerPhase
 import com.aliothmoon.maafw.runner.RunnerPort
 import com.aliothmoon.maafw.runner.StubRunnerPort
 import com.aliothmoon.maafw.runner.StubRunnerScenario
+import com.aliothmoon.maafw.runner.VirtualDisplayKey
 import com.aliothmoon.maafw.runner.isBusy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -183,6 +186,7 @@ class SessionViewModelTest {
         settings: FakeAppSettingsGateway = FakeAppSettingsGateway(),
         displaySize: FakeDisplaySizeGateway = FakeDisplaySizeGateway(),
         preview: RecordingPreviewPort = RecordingPreviewPort(),
+        servicePort: FakePrivilegedServicePort = FakePrivilegedServicePort(),
     ): Triple<SessionViewModel, InMemoryUserConfigurationStore, StubRunnerPort> {
         val focusDispatcher = idleFocusDispatcher()
         val vm = SessionViewModel(
@@ -192,7 +196,7 @@ class SessionViewModelTest {
             runLauncher = launcherFor(project, store, runner, settings),
             previewPort = preview,
             permissionGateway = permissions,
-            servicePort = FakePrivilegedServicePort(),
+            servicePort = servicePort,
             displaySize = displaySize,
             appSettings = settings,
             focusDispatcher = focusDispatcher,
@@ -280,6 +284,76 @@ class SessionViewModelTest {
             ),
             preview.touches,
         )
+    }
+
+    @Test
+    fun `virtual display keys carry the selected system key to the port`() = runTest(mainDispatcher) {
+        val preview = RecordingPreviewPort()
+        val (vm, _, _) = createVm(preview = preview)
+        advanceUntilIdle()
+
+        vm.onIntent(SessionIntent.PressVirtualDisplayKey(VirtualDisplayKey.Back))
+        vm.onIntent(SessionIntent.PressVirtualDisplayKey(VirtualDisplayKey.Home))
+        vm.onIntent(SessionIntent.PressVirtualDisplayKey(VirtualDisplayKey.Recents))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(VirtualDisplayKey.Back, VirtualDisplayKey.Home, VirtualDisplayKey.Recents),
+            preview.keys,
+        )
+    }
+
+    @Test
+    fun `virtual display key codes match Android navigation keys`() {
+        assertEquals(KeyEvent.KEYCODE_BACK, VirtualDisplayKey.Back.keyCode)
+        assertEquals(KeyEvent.KEYCODE_HOME, VirtualDisplayKey.Home.keyCode)
+        assertEquals(KeyEvent.KEYCODE_APP_SWITCH, VirtualDisplayKey.Recents.keyCode)
+    }
+
+    @Test
+    fun `virtual display keys follow display and service state`() = runTest(mainDispatcher) {
+        val service = FakePrivilegedService().apply { virtualDisplayRunning = true }
+        val servicePort = FakePrivilegedServicePort(service)
+        val permissions = FakePermissionGateway().apply {
+            serviceState.value = PrivilegedServiceState.Connected
+        }
+        val (vm, _, _) = createVm(permissions = permissions, servicePort = servicePort)
+        backgroundScope.launch { vm.uiState.collect {} }
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.virtualDisplayKeysAvailable)
+        assertFalse(vm.uiState.value.virtualDisplayKeysUnlocked)
+        assertFalse(vm.uiState.value.virtualDisplayKeysEnabled)
+
+        vm.onIntent(SessionIntent.SetVirtualDisplayKeysUnlocked(true))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.virtualDisplayKeysUnlocked)
+        assertTrue(vm.uiState.value.virtualDisplayKeysEnabled)
+
+        vm.onIntent(SessionIntent.SetVirtualDisplayKeysUnlocked(false))
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.virtualDisplayKeysEnabled)
+
+        vm.onIntent(SessionIntent.SetVirtualDisplayKeysUnlocked(true))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.virtualDisplayKeysEnabled)
+
+        permissions.serviceState.value = PrivilegedServiceState.Disconnected
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.virtualDisplayKeysAvailable)
+        assertFalse(vm.uiState.value.virtualDisplayKeysEnabled)
+        assertTrue(vm.uiState.value.virtualDisplayKeysUnlocked)
+
+        permissions.serviceState.value = PrivilegedServiceState.Connected
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.virtualDisplayKeysAvailable)
+        assertTrue(vm.uiState.value.virtualDisplayKeysEnabled)
+
+        vm.onIntent(SessionIntent.CloseTargetApp)
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.virtualDisplayKeysAvailable)
+        assertFalse(vm.uiState.value.virtualDisplayKeysEnabled)
+        assertFalse(service.virtualDisplayRunning)
     }
 
     @Test


### PR DESCRIPTION
## 摘要
- 在后台虚拟屏快捷操作中新增返回、主页和最近任务按键
- 增加仅当前进程有效的按键解锁开关，仅在虚拟屏存在且特权服务已连接时可用
- 通过 AIDL 将系统按键注入后台虚拟屏，并确保 DOWN/UP 作为同一次按压处理
- 更新主题化控件和中英文文案，补充 SessionViewModel 单元测试

## 测试
- ./gradlew :app:testDebugUnitTest --tests "com.aliothmoon.maafw.session.SessionViewModelTest"