### PR TITLE
feat: 处理虚拟屏空置状态

### DIFF
--- a/app/src/main/aidl/com/aliothmoon/maafw/RemoteService.aidl
+++ b/app/src/main/aidl/com/aliothmoon/maafw/RemoteService.aidl
@@ -103,11 +103,17 @@ interface RemoteService {
     /** MaaFramework 版本；未加载返回 null */
     String maaVersion() = 54;
 
-    /** 看门狗状态：0=IDLE / 1=WATCHING / 2=APP_DIED（目标 app 是否仍在虚拟屏上） */
+    /** 看门狗状态：0=IDLE / 1=WATCHING / 2=DISPLAY_DRIFT / 3=APP_DIED / 4=VIRTUAL_DISPLAY_EMPTY */
     int watchdogState() = 60;
 
     /** 看门狗当下盯着的包名；没有目标时为空串。运行日志要把它写进那句提示里 */
     String watchdogTargetPackage() = 61;
+
+    /**
+     * 虚拟屏当前顶层任务的包名；无屏、无顶层任务或系统查询不可用时为 null。
+     * 它回答「屏上有没有 app」，不判断画面是不是黑屏或目标 UI 是否加载完成。
+     */
+    String virtualDisplayTopPackage() = 62;
 
     // ── 亮屏与解锁 ──
 

--- a/app/src/main/java/com/aliothmoon/maafw/privileged/WatchdogState.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/privileged/WatchdogState.kt
@@ -3,9 +3,9 @@ package com.aliothmoon.maafw.privileged
 /**
  * 目标 app 在虚拟屏上的看门狗状态
  *
- * 两种坏结局分开：进程没了([APP_DIED])与进程还在但窗口跑了([DISPLAY_DRIFT])，
- * 用户要做的事完全不同——前者是应用被杀，后者多半是 ROM 把窗口挪回了主屏。
- * 名字对齐 MaaMeow 的 `appDiedEvent` / `displayDriftEvent`
+ * 异常结局分开：进程没了([APP_DIED])、进程还在但窗口跑了([DISPLAY_DRIFT])、
+ * 虚拟屏还没有应用任务([VIRTUAL_DISPLAY_EMPTY])。前两者表示这一轮已丢目标；
+ * 第三种只提示启动缺失或延迟，PI 稍后执行 start_app 时会自动转回 WATCHING。
  *
  * [aidlValue] 对齐 RemoteService.watchdogState() 的 AIDL 契约（特权进程返回 int），
  * app 侧用 [fromAidl] 映射回枚举；PermissionGateway 把它投影给 ViewModel/预览徽标
@@ -18,10 +18,16 @@ enum class WatchdogState(val aidlValue: Int) {
     DISPLAY_DRIFT(2),
 
     /** pidof 查不到进程 */
-    APP_DIED(3);
+    APP_DIED(3),
+
+    /** 虚拟屏上还没有任何可识别的顶层应用任务 */
+    VIRTUAL_DISPLAY_EMPTY(4);
 
     /** 两者都表示这一轮已经跑不下去了，UI 与运行日志按同一档处理 */
     val isLost: Boolean get() = this == DISPLAY_DRIFT || this == APP_DIED
+
+    /** 空屏不一定是终局：PI 可能稍后才执行 start_app，因此只提示，不当成丢目标 */
+    val needsNotice: Boolean get() = isLost || this == VIRTUAL_DISPLAY_EMPTY
 
     companion object {
         fun fromAidl(value: Int): WatchdogState =

--- a/app/src/main/java/com/aliothmoon/maafw/remote/RemoteServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/RemoteServiceImpl.kt
@@ -84,6 +84,12 @@ class RemoteServiceImpl : RemoteService.Stub() {
 
     override fun watchdogTargetPackage(): String = AppWatchdog.targetPackage.orEmpty()
 
+    override fun virtualDisplayTopPackage(): String? {
+        val displayId = VirtualDisplayManager.getDisplayId()
+        if (displayId == DefaultDisplayConfig.DISPLAY_NONE) return null
+        return ActivityUtils.getTopPackageOnDisplay(displayId)
+    }
+
     // ── 亮屏与解锁 ──
 
     override fun unlock(credential: String?): Int =

--- a/app/src/main/java/com/aliothmoon/maafw/remote/internal/AppWatchdog.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/remote/internal/AppWatchdog.kt
@@ -33,6 +33,9 @@ object AppWatchdog {
     /** pidof 查不到进程 */
     const val STATE_APP_DIED = 3
 
+    /** 虚拟屏上还没有任何顶层应用任务 */
+    const val STATE_VIRTUAL_DISPLAY_EMPTY = 4
+
     private const val POLL_INTERVAL_MS = 5000L
     private const val REPIN_GRACE_MS = 5000L
     private const val MAX_REPIN_ATTEMPTS = 3
@@ -95,7 +98,7 @@ object AppWatchdog {
 
         val pkg = targetPackage
         if (pkg == null) {
-            _state.value = STATE_IDLE
+            _state.value = STATE_VIRTUAL_DISPLAY_EMPTY
             return
         }
 

--- a/app/src/main/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPort.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPort.kt
@@ -316,6 +316,14 @@ class MaaFrameworkRunnerPort(
         if (service.startVirtualDisplay() == DefaultDisplayConfig.DISPLAY_NONE) {
             return if (mode == RunMode.FOREGROUND) uiTextOf(R.string.msg_reject_primary_capture) else uiTextOf(R.string.msg_reject_virtual_display)
         }
+        if (mode == RunMode.BACKGROUND) {
+            val topPackage = runCatching { service.virtualDisplayTopPackage() }
+                .onFailure { Timber.w(it, "virtualDisplayTopPackage failed") }
+            // 调用失败视为旧特权进程暂不支持该检查；明确的 null 才代表空屏
+            if (topPackage.isSuccess && topPackage.getOrNull() == null) {
+                return uiTextOf(R.string.msg_reject_virtual_display_empty)
+            }
+        }
 
         bindRunnerCallback(service)
 

--- a/app/src/main/java/com/aliothmoon/maafw/runner/WatchdogNoticeHook.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/runner/WatchdogNoticeHook.kt
@@ -43,9 +43,9 @@ class WatchdogNoticeHook(
         val job = scope.launch {
             watchdogState
                 // 上一轮留下的坏状态还没被 2s 轮询刷掉，别拿它当本轮的事
-                .dropWhile { it.isLost }
+                .dropWhile { it.needsNotice }
                 .distinctUntilChanged()
-                .filter { it.isLost }
+                .filter { it.needsNotice }
                 .collect { state -> journal.note(RunNote.Warning, describe(state)) }
         }
         return EngageResult.Engaged { job.cancel() }
@@ -54,6 +54,7 @@ class WatchdogNoticeHook(
     private suspend fun describe(state: WatchdogState) = uiTextOf(
         when (state) {
             WatchdogState.APP_DIED -> R.string.run_log_app_process_gone
+            WatchdogState.VIRTUAL_DISPLAY_EMPTY -> R.string.run_log_virtual_display_empty
             else -> R.string.run_log_app_left_display
         },
         targetPackage(),

--- a/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksPreviewSection.kt
+++ b/app/src/main/java/com/aliothmoon/maafw/ui/tasks/TasksPreviewSection.kt
@@ -182,6 +182,8 @@ private fun WatchdogStatusBadge(state: WatchdogState, modifier: Modifier = Modif
             Color(0xFFF44336) to stringResource(R.string.virtual_display_game_stopped)
         WatchdogState.DISPLAY_DRIFT ->
             Color(0xFFF44336) to stringResource(R.string.virtual_display_app_drifted)
+        WatchdogState.VIRTUAL_DISPLAY_EMPTY ->
+            Color(0xFFFFC107) to stringResource(R.string.virtual_display_empty)
         WatchdogState.IDLE ->
             Color(0xFF9E9E9E) to stringResource(R.string.virtual_display_idle)
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -28,6 +28,7 @@
     <string name="virtual_display_game_running">Running</string>
     <string name="virtual_display_game_stopped">Stopped</string>
     <string name="virtual_display_app_drifted">Off-display</string>
+    <string name="virtual_display_empty">Empty</string>
     <string name="virtual_display_idle">Idle</string>
     <string name="tasks_preview_exit_fullscreen">Exit fullscreen</string>
     <string name="tasks_preview_idle">Not running</string>
@@ -383,6 +384,7 @@
     <string name="msg_reject_switch_display_mode">Failed to switch display mode: %1$s</string>
     <string name="msg_reject_primary_capture">Failed to start primary screen capture</string>
     <string name="msg_reject_virtual_display">Virtual display failed to start; check service permissions</string>
+    <string name="msg_reject_virtual_display_empty">No app task is on the virtual display; start the target app first</string>
     <string name="msg_reject_service_rejected">Privileged process rejected the run</string>
 
     <!-- Server switching & run options -->
@@ -468,6 +470,7 @@
     <string name="run_log_agent_flood">Agent output is flooding; display paused. Full output goes to logcat.</string>
     <string name="run_log_app_left_display">The target app left the virtual display and could not be moved back (%1$s). Try foreground mode instead.</string>
     <string name="run_log_app_process_gone">The target app process is not running or was closed unexpectedly (%1$s).</string>
+    <string name="run_log_virtual_display_empty">No app task is on the virtual display yet; start the target app manually if this project does not start it.</string>
     <string name="run_log_app_unknown">unknown app</string>
     <string name="run_log_agent_flood_recovered">Agent output is back to normal</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="virtual_display_game_running">运行中</string>
     <string name="virtual_display_game_stopped">已停止</string>
     <string name="virtual_display_app_drifted">已离屏</string>
+    <string name="virtual_display_empty">空屏</string>
     <string name="virtual_display_idle">空闲</string>
     <string name="tasks_preview_exit_fullscreen">退出全屏</string>
     <string name="tasks_preview_idle">未在运行</string>
@@ -376,6 +377,7 @@
     <string name="msg_reject_switch_display_mode">切换显示模式失败：%1$s</string>
     <string name="msg_reject_primary_capture">主屏采集启动失败</string>
     <string name="msg_reject_virtual_display">虚拟屏幕启动失败，请检查服务权限</string>
+    <string name="msg_reject_virtual_display_empty">虚拟屏幕上没有应用任务，请先启动目标应用</string>
     <string name="msg_reject_service_rejected">特权进程拒绝了本次执行</string>
 
     <!-- 资源切换与运行选项 -->
@@ -460,6 +462,7 @@
     <string name="run_log_agent_flood">Agent 输出过快，已暂停显示；完整输出见 logcat</string>
     <string name="run_log_app_left_display">目标应用已离开虚拟显示器且自动拉回失败(%1$s)，可改用前台模式</string>
     <string name="run_log_app_process_gone">目标应用进程未启动或被异常关闭(%1$s)</string>
+    <string name="run_log_virtual_display_empty">虚拟屏幕上还没有应用任务；若项目不会自动启动目标应用，请先手动启动</string>
     <string name="run_log_app_unknown">未知应用</string>
     <string name="run_log_agent_flood_recovered">Agent 输出已恢复正常</string>
 

--- a/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/privileged/FakePrivilegedService.kt
@@ -31,6 +31,7 @@ open class FakePrivilegedService : RemoteService {
         private set
     var stopTargetAppCount: Int = 0
         private set
+    var virtualDisplayTopPackage: String? = "com.example.app"
 
     var runnerCallback: IMaaRunnerCallback? = null
         private set
@@ -103,6 +104,7 @@ open class FakePrivilegedService : RemoteService {
     override fun testUnlock(credential: String?): Int = unlockResult
     override fun watchdogState(): Int = 0
     override fun watchdogTargetPackage(): String = ""
+    override fun virtualDisplayTopPackage(): String? = virtualDisplayTopPackage
 
     /** 缓存帧要真 controller 才有；测试里没有可落盘的东西 */
     override fun saveCachedImage(path: String?): Boolean = false

--- a/app/src/test/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPortTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/MaaFrameworkRunnerPortTest.kt
@@ -86,6 +86,19 @@ class MaaFrameworkRunnerPortTest {
     }
 
     @Test
+    fun `empty virtual display is rejected before dispatch`() = runTest(dispatcher) {
+        val service = FakePrivilegedService().apply { virtualDisplayTopPackage = null }
+        val (runner, _) = port(this, service)
+
+        val result = runner.start(plan())
+        advanceUntilIdle()
+
+        assertTrue(result is RunnerCommandResult.Rejected)
+        assertEquals(RunnerPhase.Idle, runner.state.value.phase)
+        assertTrue(runner.state.value.latestResult is ExecutionResult.Failed)
+    }
+
+    @Test
     fun `stop during prepare is retried after start returns`() = runTest(dispatcher) {
         val service = FakePrivilegedService()
         val hold = CompletableDeferred<Unit>()

--- a/app/src/test/java/com/aliothmoon/maafw/runner/WatchdogNoticeHookTest.kt
+++ b/app/src/test/java/com/aliothmoon/maafw/runner/WatchdogNoticeHookTest.kt
@@ -1,0 +1,91 @@
+package com.aliothmoon.maafw.runner
+
+import com.aliothmoon.maafw.MaaDispatchers
+import com.aliothmoon.maafw.R
+import com.aliothmoon.maafw.domain.ControllerDefinition
+import com.aliothmoon.maafw.domain.ResourceDefinition
+import com.aliothmoon.maafw.domain.RunConfigurationId
+import com.aliothmoon.maafw.domain.RunMode
+import com.aliothmoon.maafw.i18n.UiText
+import com.aliothmoon.maafw.privileged.FakePrivilegedService
+import com.aliothmoon.maafw.privileged.FakePrivilegedServicePort
+import com.aliothmoon.maafw.privileged.WatchdogState
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WatchdogNoticeHookTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        mockkObject(MaaDispatchers)
+        every { MaaDispatchers.IO } returns dispatcher
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(MaaDispatchers)
+    }
+
+    private class RecordingJournal : RunJournal {
+        val notes = mutableListOf<Pair<RunNote, UiText.Resource>>()
+
+        override suspend fun begin(plan: RunPlan) = Unit
+
+        override suspend fun end(reason: RunEndReason) = Unit
+
+        override fun note(level: RunNote, text: UiText) {
+            if (text is UiText.Resource) notes += level to text
+        }
+    }
+
+    private fun TestScope.context(journal: RunJournal) = RunContext(
+        trigger = RunTrigger.Manual,
+        runMode = RunMode.BACKGROUND,
+        plan = RunPlan(
+            projectName = "demo",
+            projectVersion = "1",
+            controller = ControllerDefinition(),
+            resource = ResourceDefinition("官服", listOf("./base")),
+            runConfigurationId = RunConfigurationId("c1"),
+            tasks = emptyList(),
+        ),
+        journal = journal,
+    )
+
+    @Test
+    fun `empty virtual display warns once and stays quiet after recovery`() = runTest(dispatcher) {
+        val state = MutableStateFlow(WatchdogState.IDLE)
+        val journal = RecordingJournal()
+        val servicePort = FakePrivilegedServicePort(FakePrivilegedService())
+        val hook = WatchdogNoticeHook(state, servicePort, journal, this)
+
+        val result = hook.engage(context(journal))
+        advanceUntilIdle()
+        state.value = WatchdogState.VIRTUAL_DISPLAY_EMPTY
+        advanceUntilIdle()
+        state.value = WatchdogState.WATCHING
+        advanceUntilIdle()
+
+        val engaged = result as EngageResult.Engaged
+        engaged.release(RunEndReason.NotRun(NotRunCause.Cancelled))
+
+        assertEquals(
+            listOf(RunNote.Warning to R.string.run_log_virtual_display_empty),
+            journal.notes.map { (level, text) -> level to text.resId },
+        )
+    }
+}


### PR DESCRIPTION
## 概要
- 特权服务新增虚拟屏顶层包名查询
- 后台模式启动时，如果虚拟屏上没有应用任务则拒绝执行
- 在 UI 和运行日志中区分虚拟屏空置状态
- 若旧版特权服务不支持新 RPC，则跳过该检查，保持兼容

## 测试
- ./gradlew :app:testDebugUnitTest --tests 'com.aliothmoon.maafw.runner.*'
- ./gradlew test
- ./gradlew :app:compileDebugKotlin